### PR TITLE
Add options to langchain chain creation function

### DIFF
--- a/kor/encoders/__init__.py
+++ b/kor/encoders/__init__.py
@@ -5,9 +5,16 @@ An encoder follows the `Encoder` interface.
 It can encode, decode and contains instructions about the encoding format for an LLM.
 """
 from .csv_data import CSVEncoder
-from .encode import encode_examples
+from .encode import encode_examples, initialize_encoder
 from .json_data import JSONEncoder
 from .typedefs import Encoder
 from .xml import XMLEncoder
 
-__all__ = ["Encoder", "XMLEncoder", "CSVEncoder", "JSONEncoder", "encode_examples"]
+__all__ = [
+    "Encoder",
+    "XMLEncoder",
+    "CSVEncoder",
+    "JSONEncoder",
+    "encode_examples",
+    "initialize_encoder",
+]

--- a/kor/encoders/csv_data.py
+++ b/kor/encoders/csv_data.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from kor.encoders.typedefs import Encoder
+from kor.encoders.typedefs import SchemaBasedEncoder
 from kor.nodes import AbstractSchemaNode, Object
 
 DELIMITER = "|"
@@ -39,7 +39,7 @@ def _get_table_content(string: str) -> Optional[str]:
 # PUBLIC API
 
 
-class CSVEncoder(Encoder):
+class CSVEncoder(SchemaBasedEncoder):
     """CSV encoder."""
 
     def __init__(self, node: AbstractSchemaNode) -> None:

--- a/kor/encoders/encode.py
+++ b/kor/encoders/encode.py
@@ -28,8 +28,8 @@ def initialize_encoder(
     """Flexible way to initialize an encoder, used only for top level API.
 
     Args:
-        encoder_or_encoder_class: Either an encoder instance, an encoder class or a string
-                                  representing the encoder class.
+        encoder_or_encoder_class: Either an encoder instance, an encoder class
+                                  or a string representing the encoder class.
         schema: The schema to use for the encoder.
         **kwargs: Keyword arguments to pass to the encoder class.
 

--- a/kor/encoders/encode.py
+++ b/kor/encoders/encode.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Sequence, Tuple, Type, Union, Mapping
+from typing import Any, List, Mapping, Sequence, Tuple, Type, Union
 
 from kor.nodes import AbstractSchemaNode
 
@@ -6,7 +6,6 @@ from .csv_data import CSVEncoder
 from .json_data import JSONEncoder
 from .typedefs import Encoder, SchemaBasedEncoder
 from .xml import XMLEncoder
-
 
 _ENCODER_REGISTRY: Mapping[str, Type[Encoder]] = {
     "csv": CSVEncoder,

--- a/kor/encoders/encode.py
+++ b/kor/encoders/encode.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Sequence, Tuple, Type, Union
+from typing import Any, List, Sequence, Tuple, Type, Union, Mapping
 
 from kor.nodes import AbstractSchemaNode
 
@@ -6,6 +6,13 @@ from .csv_data import CSVEncoder
 from .json_data import JSONEncoder
 from .typedefs import Encoder, SchemaBasedEncoder
 from .xml import XMLEncoder
+
+
+_ENCODER_REGISTRY: Mapping[str, Type[Encoder]] = {
+    "csv": CSVEncoder,
+    "xml": XMLEncoder,
+    "json": JSONEncoder,
+}
 
 # PUBLIC API
 
@@ -37,12 +44,12 @@ def initialize_encoder(
         An encoder instance
     """
     if isinstance(encoder_or_encoder_class, str):
-        encoder_or_encoder_class = {
-            "csv": CSVEncoder,
-            "xml": XMLEncoder,
-            "json": JSONEncoder,
-        }[encoder_or_encoder_class.lower()]
-
+        encoder_name = encoder_or_encoder_class.lower()
+        if encoder_name not in _ENCODER_REGISTRY:
+            raise ValueError(
+                f"Unknown encoder {encoder_name}. Use one of {sorted(_ENCODER_REGISTRY)}"
+            )
+        encoder_or_encoder_class = _ENCODER_REGISTRY[encoder_name]
     if isinstance(encoder_or_encoder_class, type(Encoder)):
         if issubclass(encoder_or_encoder_class, SchemaBasedEncoder):
             return encoder_or_encoder_class(schema, **kwargs)

--- a/kor/encoders/encode.py
+++ b/kor/encoders/encode.py
@@ -22,7 +22,7 @@ def encode_examples(
 
 def initialize_encoder(
     encoder_or_encoder_class: Union[Type[Encoder], Encoder, str],
-    schema: Optional[AbstractSchemaNode] = None,
+    schema: AbstractSchemaNode,
     **kwargs: Any,
 ) -> Encoder:
     """Flexible way to initialize an encoder, used only for top level API.
@@ -30,6 +30,7 @@ def initialize_encoder(
     Args:
         encoder_or_encoder_class: Either an encoder instance, an encoder class or a string
                                   representing the encoder class.
+        schema: The schema to use for the encoder.
         **kwargs: Keyword arguments to pass to the encoder class.
 
     Returns:
@@ -46,10 +47,6 @@ def initialize_encoder(
         if issubclass(encoder_or_encoder_class, SchemaBasedEncoder):
             return encoder_or_encoder_class(schema, **kwargs)
         else:
-            if schema is not None:
-                raise ValueError(
-                    "Unable to use a schema with an encoder that does not use a schema"
-                )
             return encoder_or_encoder_class(**kwargs)
     elif isinstance(encoder_or_encoder_class, Encoder):
         if kwargs:

--- a/kor/encoders/encode.py
+++ b/kor/encoders/encode.py
@@ -46,7 +46,8 @@ def initialize_encoder(
         encoder_name = encoder_or_encoder_class.lower()
         if encoder_name not in _ENCODER_REGISTRY:
             raise ValueError(
-                f"Unknown encoder {encoder_name}. Use one of {sorted(_ENCODER_REGISTRY)}"
+                f"Unknown encoder {encoder_name}. "
+                f"Use one of {sorted(_ENCODER_REGISTRY)}"
             )
         encoder_or_encoder_class = _ENCODER_REGISTRY[encoder_name]
     if isinstance(encoder_or_encoder_class, type(Encoder)):

--- a/kor/encoders/encode.py
+++ b/kor/encoders/encode.py
@@ -57,5 +57,6 @@ def initialize_encoder(
         return encoder_or_encoder_class
     else:
         raise TypeError(
-            f"Expected str, an encoder or encoder class, got {type(encoder_or_encoder_class)}"
+            "Expected str, an encoder or encoder class, got"
+            f" {type(encoder_or_encoder_class)}"
         )

--- a/kor/encoders/encode.py
+++ b/kor/encoders/encode.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, List, Sequence, Tuple, Type, Union
 
 from kor.nodes import AbstractSchemaNode
 

--- a/kor/encoders/typedefs.py
+++ b/kor/encoders/typedefs.py
@@ -13,10 +13,6 @@ from kor.nodes import AbstractSchemaNode
 
 
 class Encoder(abc.ABC):
-    def __init__(self, node: AbstractSchemaNode) -> None:
-        """Attach node to the encoder to allow the encoder to understand schema."""
-        self.node = node
-
     @abc.abstractmethod
     def encode(self, data: Any) -> str:
         """Encode the examples."""
@@ -29,3 +25,9 @@ class Encoder(abc.ABC):
     def get_instruction_segment(self) -> str:
         """Format instruction segment."""
         raise NotImplementedError()
+
+
+class SchemaBasedEncoder(Encoder):
+    def __init__(self, node: AbstractSchemaNode) -> None:
+        """Attach node to the encoder to allow the encoder to understand schema."""
+        self.node = node

--- a/kor/encoders/typedefs.py
+++ b/kor/encoders/typedefs.py
@@ -28,6 +28,6 @@ class Encoder(abc.ABC):
 
 
 class SchemaBasedEncoder(Encoder):
-    def __init__(self, node: AbstractSchemaNode) -> None:
+    def __init__(self, node: AbstractSchemaNode, **kwargs: Any) -> None:
         """Attach node to the encoder to allow the encoder to understand schema."""
         self.node = node

--- a/kor/extraction.py
+++ b/kor/extraction.py
@@ -1,12 +1,12 @@
 from typing import Any, Type, Union
 
-from langchain.chains import LLMChain
-from langchain.schema import BaseLanguageModel
-
 from kor.encoders import Encoder, initialize_encoder
 from kor.nodes import AbstractSchemaNode
 from kor.prompts import create_langchain_prompt
-from kor.type_descriptors import TypeDescriptor
+from kor.type_descriptors import TypeDescriptor, initialize_type_descriptors
+from langchain.chains import LLMChain
+from langchain.schema import BaseLanguageModel
+
 
 # PUBLIC API
 
@@ -18,6 +18,22 @@ def create_extraction_chain(
     type_descriptor: Union[TypeDescriptor, str] = "typescript",
     **encoder_kwargs: Any,
 ) -> LLMChain:
-    """Create an extraction chain."""
+    """Create an extraction chain.
+
+    Args:
+        llm: The language model used for extraction
+        schema: the schematic description of what to extract from text
+        encoder_or_encoder_class: Either an encoder instance, an encoder class or a string
+                                    representing the encoder class
+        type_descriptor: The type descriptor to use. This can be either a TypeDescriptor
+                          or a string representing the type descriptor name
+        encoder_kwargs: Keyword arguments to pass to the encoder class
+
+    Returns:
+        A langchain chain
+    """
     encoder = initialize_encoder(encoder_or_encoder_class, schema, **encoder_kwargs)
-    return LLMChain(llm=llm, prompt=create_langchain_prompt(encoder, type_descriptor))
+    type_descriptor_to_use = initialize_type_descriptors(type_descriptor)
+    return LLMChain(
+        llm=llm, prompt=create_langchain_prompt(encoder, type_descriptor_to_use)
+    )

--- a/kor/extraction.py
+++ b/kor/extraction.py
@@ -1,12 +1,12 @@
+from typing import Any, Type, Union
+
 from langchain.chains import LLMChain
 from langchain.schema import BaseLanguageModel
-from typing import Any, Type, Union
 
 from kor.encoders import Encoder, initialize_encoder
 from kor.nodes import AbstractSchemaNode
 from kor.prompts import create_langchain_prompt
 from kor.type_descriptors import TypeDescriptor, initialize_type_descriptors
-
 
 # PUBLIC API
 

--- a/kor/extraction.py
+++ b/kor/extraction.py
@@ -1,7 +1,10 @@
+from typing import Any, Type, Union
+
 from langchain.chains import LLMChain
 from langchain.schema import BaseLanguageModel
 
-from kor.encoders import Encoder
+from kor.encoders import Encoder, initialize_encoder
+from kor.nodes import AbstractSchemaNode
 from kor.prompts import create_langchain_prompt
 from kor.type_descriptors import TypeDescriptor
 
@@ -9,7 +12,12 @@ from kor.type_descriptors import TypeDescriptor
 
 
 def create_extraction_chain(
-    llm: BaseLanguageModel, encoder: Encoder, type_descriptor: TypeDescriptor
+    llm: BaseLanguageModel,
+    schema: AbstractSchemaNode,
+    encoder_or_encoder_class: Union[Type[Encoder], Encoder, str] = "json",
+    type_descriptor: Union[TypeDescriptor, str] = "typescript",
+    **encoder_kwargs: Any,
 ) -> LLMChain:
     """Create an extraction chain."""
+    encoder = initialize_encoder(encoder_or_encoder_class, schema, **encoder_kwargs)
     return LLMChain(llm=llm, prompt=create_langchain_prompt(encoder, type_descriptor))

--- a/kor/extraction.py
+++ b/kor/extraction.py
@@ -13,7 +13,7 @@ from langchain.schema import BaseLanguageModel
 
 def create_extraction_chain(
     llm: BaseLanguageModel,
-    schema: AbstractSchemaNode,
+    node: AbstractSchemaNode,
     encoder_or_encoder_class: Union[Type[Encoder], Encoder, str] = "json",
     type_descriptor: Union[TypeDescriptor, str] = "typescript",
     **encoder_kwargs: Any,
@@ -22,7 +22,7 @@ def create_extraction_chain(
 
     Args:
         llm: The language model used for extraction
-        schema: the schematic description of what to extract from text
+        node: the schematic description of what to extract from text
         encoder_or_encoder_class: Either an encoder instance, an encoder class or a string
                                     representing the encoder class
         type_descriptor: The type descriptor to use. This can be either a TypeDescriptor
@@ -32,8 +32,8 @@ def create_extraction_chain(
     Returns:
         A langchain chain
     """
-    encoder = initialize_encoder(encoder_or_encoder_class, schema, **encoder_kwargs)
+    encoder = initialize_encoder(encoder_or_encoder_class, node, **encoder_kwargs)
     type_descriptor_to_use = initialize_type_descriptors(type_descriptor)
     return LLMChain(
-        llm=llm, prompt=create_langchain_prompt(encoder, type_descriptor_to_use)
+        llm=llm, prompt=create_langchain_prompt(node, encoder, type_descriptor_to_use)
     )

--- a/kor/extraction.py
+++ b/kor/extraction.py
@@ -1,12 +1,12 @@
 from typing import Any, Type, Union
 
+from langchain.chains import LLMChain
+from langchain.schema import BaseLanguageModel
+
 from kor.encoders import Encoder, initialize_encoder
 from kor.nodes import AbstractSchemaNode
 from kor.prompts import create_langchain_prompt
 from kor.type_descriptors import TypeDescriptor, initialize_type_descriptors
-from langchain.chains import LLMChain
-from langchain.schema import BaseLanguageModel
-
 
 # PUBLIC API
 

--- a/kor/extraction.py
+++ b/kor/extraction.py
@@ -1,12 +1,12 @@
-from typing import Any, Type, Union
-
 from langchain.chains import LLMChain
 from langchain.schema import BaseLanguageModel
+from typing import Any, Type, Union
 
 from kor.encoders import Encoder, initialize_encoder
 from kor.nodes import AbstractSchemaNode
 from kor.prompts import create_langchain_prompt
 from kor.type_descriptors import TypeDescriptor, initialize_type_descriptors
+
 
 # PUBLIC API
 
@@ -14,6 +14,7 @@ from kor.type_descriptors import TypeDescriptor, initialize_type_descriptors
 def create_extraction_chain(
     llm: BaseLanguageModel,
     node: AbstractSchemaNode,
+    *,
     encoder_or_encoder_class: Union[Type[Encoder], Encoder, str] = "json",
     type_descriptor: Union[TypeDescriptor, str] = "typescript",
     **encoder_kwargs: Any,
@@ -23,8 +24,8 @@ def create_extraction_chain(
     Args:
         llm: The language model used for extraction
         node: the schematic description of what to extract from text
-        encoder_or_encoder_class: Either an encoder instance, an encoder class or a string
-                                    representing the encoder class
+        encoder_or_encoder_class: Either an encoder instance, an encoder class
+                                  or a string representing the encoder class
         type_descriptor: The type descriptor to use. This can be either a TypeDescriptor
                           or a string representing the type descriptor name
         encoder_kwargs: Keyword arguments to pass to the encoder class

--- a/kor/prompts.py
+++ b/kor/prompts.py
@@ -1,18 +1,13 @@
 """Code to dynamically generate appropriate LLM prompts."""
 from __future__ import annotations
 
-from typing import Any, List, Literal, Tuple, Union
-
 from langchain import BasePromptTemplate
 from langchain.output_parsers import BaseOutputParser
 from langchain.schema import (
-    AIMessage,
-    BaseMessage,
-    HumanMessage,
-    PromptValue,
-    SystemMessage,
+    AIMessage, BaseMessage, HumanMessage, PromptValue, SystemMessage,
 )
 from pydantic import Extra
+from typing import Any, List, Literal, Tuple, Union
 
 from kor.encoders import Encoder
 from kor.encoders.encode import encode_examples
@@ -28,6 +23,7 @@ class ExtractionPromptValue(PromptValue):
 
     text: str
     encoder: Encoder
+    node: AbstractSchemaNode
     type_descriptor: TypeDescriptor
     prefix: str = (
         "Your goal is to extract structured information from the user's input that"
@@ -44,9 +40,8 @@ class ExtractionPromptValue(PromptValue):
 
     def to_string(self) -> str:
         """Format the template to a string."""
-        node = self.encoder.node
-        instruction_segment = self.generate_instruction_segment(node)
-        encoded_examples = self.generate_encoded_examples(node)
+        instruction_segment = self.generate_instruction_segment(self.node)
+        encoded_examples = self.generate_encoded_examples(self.node)
         formatted_examples: List[str] = []
 
         for in_example, output in encoded_examples:
@@ -63,11 +58,10 @@ class ExtractionPromptValue(PromptValue):
 
     def to_messages(self) -> List[BaseMessage]:
         """Format the template to chat messages."""
-        node = self.encoder.node
-        instruction_segment = self.generate_instruction_segment(node)
+        instruction_segment = self.generate_instruction_segment(self.node)
 
         messages: List[BaseMessage] = [SystemMessage(content=instruction_segment)]
-        encoded_examples = self.generate_encoded_examples(node)
+        encoded_examples = self.generate_encoded_examples(self.node)
 
         for example_input, example_output in encoded_examples:
             messages.extend(
@@ -98,6 +92,7 @@ class ExtractionPromptTemplate(BasePromptTemplate):
     """Extraction prompt template."""
 
     encoder: Encoder
+    node: AbstractSchemaNode
     type_descriptor: TypeDescriptor
 
     class Config:
@@ -113,6 +108,7 @@ class ExtractionPromptTemplate(BasePromptTemplate):
         return ExtractionPromptValue(
             text=text,
             encoder=self.encoder,
+            node=self.node,
             type_descriptor=self.type_descriptor,
         )
 
@@ -155,12 +151,13 @@ class KorParser(BaseOutputParser):
 
 
 def create_langchain_prompt(
-    encoder: Encoder, type_descriptor: TypeDescriptor
+    schema: AbstractSchemaNode, encoder: Encoder, type_descriptor: TypeDescriptor
 ) -> ExtractionPromptTemplate:
     """Create a langchain style prompt with specified encoder."""
     return ExtractionPromptTemplate(
         input_variables=["text"],
         output_parser=KorParser(encoder=encoder),
         encoder=encoder,
+        node=schema,
         type_descriptor=type_descriptor,
     )

--- a/kor/prompts.py
+++ b/kor/prompts.py
@@ -1,13 +1,18 @@
 """Code to dynamically generate appropriate LLM prompts."""
 from __future__ import annotations
 
+from typing import Any, List, Literal, Tuple, Union
+
 from langchain import BasePromptTemplate
 from langchain.output_parsers import BaseOutputParser
 from langchain.schema import (
-    AIMessage, BaseMessage, HumanMessage, PromptValue, SystemMessage,
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    PromptValue,
+    SystemMessage,
 )
 from pydantic import Extra
-from typing import Any, List, Literal, Tuple, Union
 
 from kor.encoders import Encoder
 from kor.encoders.encode import encode_examples

--- a/kor/type_descriptors.py
+++ b/kor/type_descriptors.py
@@ -7,7 +7,7 @@ Designing the code here to make it easier to experiment with different ways
 of describing the schema.
 """
 import abc
-from typing import List, TypeVar
+from typing import List, TypeVar, Union
 
 from kor.nodes import (
     AbstractSchemaNode,
@@ -129,3 +129,20 @@ class TypeScriptTypeGenerator(TypeDescriptor[None]):
             self.code_lines.append("}")
 
         return f"```TypeScript\n\n{self.get_type_description()}\n```\n"
+
+
+def initialize_type_descriptors(
+    type_descriptor: Union[TypeDescriptor, str]
+) -> TypeDescriptor:
+    """Initialize the type descriptors."""
+    if isinstance(type_descriptor, str):
+        if type_descriptor == "bullet_point":
+            return BulletPointTypeGenerator()
+        elif type_descriptor == "typescript":
+            return TypeScriptTypeGenerator()
+        else:
+            raise ValueError(
+                f"Unknown type descriptor: {type_descriptor}. Use one of: bullet_point, typescript "
+                f"or else provide an instance of TypeDescriptor."
+            )
+    return type_descriptor

--- a/kor/type_descriptors.py
+++ b/kor/type_descriptors.py
@@ -142,7 +142,7 @@ def initialize_type_descriptors(
             return TypeScriptTypeGenerator()
         else:
             raise ValueError(
-                f"Unknown type descriptor: {type_descriptor}. Use one of: bullet_point, typescript "
-                f"or else provide an instance of TypeDescriptor."
+                f"Unknown type descriptor: {type_descriptor}. Use one of: bullet_point,"
+                " typescript or else provide an instance of TypeDescriptor."
             )
     return type_descriptor

--- a/tests/test_encoders/test_encoders.py
+++ b/tests/test_encoders/test_encoders.py
@@ -48,7 +48,7 @@ def _get_schema() -> AbstractSchemaNode:
 def test_xml_encoding(node_data: Any, expected: str) -> None:
     """Test XML encoding."""
     node = _get_schema()
-    xml_encoder = XMLEncoder(node)  # None
+    xml_encoder = XMLEncoder()
     assert xml_encoder.encode(node_data) == expected
 
 
@@ -66,5 +66,5 @@ def test_xml_encoding(node_data: Any, expected: str) -> None:
 def test_json_encoding(node_data: Any, expected: str) -> None:
     """Test JSON encoding. This is just json.dumps, so no need to test extensively."""
     node = _get_schema()
-    xml_encoder = JSONEncoder(node)  # None
+    xml_encoder = JSONEncoder()
     assert xml_encoder.encode(node_data) == expected

--- a/tests/test_encoders/test_encoders.py
+++ b/tests/test_encoders/test_encoders.py
@@ -47,7 +47,6 @@ def _get_schema() -> AbstractSchemaNode:
 )
 def test_xml_encoding(node_data: Any, expected: str) -> None:
     """Test XML encoding."""
-    node = _get_schema()
     xml_encoder = XMLEncoder()
     assert xml_encoder.encode(node_data) == expected
 
@@ -65,6 +64,5 @@ def test_xml_encoding(node_data: Any, expected: str) -> None:
 )
 def test_json_encoding(node_data: Any, expected: str) -> None:
     """Test JSON encoding. This is just json.dumps, so no need to test extensively."""
-    node = _get_schema()
     xml_encoder = JSONEncoder()
     assert xml_encoder.encode(node_data) == expected

--- a/tests/test_encoders/test_xml.py
+++ b/tests/test_encoders/test_xml.py
@@ -25,7 +25,7 @@ from kor.encoders.xml import XMLEncoder, _write_tag
 )
 def test_xml_decode(xml_string: str, output: Any) -> None:
     """Decode XML."""
-    encoder = XMLEncoder(None)  # type: ignore[arg-type]
+    encoder = XMLEncoder()
     assert encoder.decode(xml_string) == output
 
 
@@ -53,7 +53,7 @@ def test_xml_decode(xml_string: str, output: Any) -> None:
 )
 def test_xml_encode(obj: Any, output: Union[Type[Exception], str]) -> None:
     """Test XML encoding."""
-    encoder = XMLEncoder(None)  # type: ignore[arg-type]
+    encoder = XMLEncoder()
     if isinstance(output, str):
         assert encoder.encode(obj) == output
     else:


### PR DESCRIPTION
This PRs adds more options to instantiate a langchain chain conveniently using the entry point API in extraction module.

Also making some tweaks in the encoder APIs to define encoders that require schematic information.

There might still be further changes here since there are a few awkward things.