### PR TITLE
Add pydantic adapter

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -88,4 +88,5 @@ Translate user input into structured JSON to use for an API **request**:
    nested_objects
    untyped_objects
    apis
+   validation
 

--- a/docs/source/validation.ipynb
+++ b/docs/source/validation.ipynb
@@ -90,23 +90,32 @@
    "outputs": [],
    "source": [
     "class Action(enum.Enum):\n",
-    "    play = 'play'\n",
-    "    stop = 'stop'\n",
-    "    previous = 'previous'\n",
-    "    next_ = 'next'\n",
+    "    play = \"play\"\n",
+    "    stop = \"stop\"\n",
+    "    previous = \"previous\"\n",
+    "    next_ = \"next\"\n",
+    "\n",
     "\n",
     "class MusicRequest(BaseModel):\n",
-    "    song: Optional[List[str]] = Field(description='The song(s) that the user would like to be played.')\n",
-    "    album: Optional[List[str]] = Field(description='The album(s) that the user would like to be played.')\n",
-    "    artist: Optional[List[str]] = Field(description='The artist(s) whose music the user would like to hear.', examples=[(\"Songs by paul simon\", \"paul simon\")])\n",
-    "    action: Optional[Action] = Field(description='The action that should be taken; one of `play`, `stop`, `next`, `previous`', \n",
-    "                                  examples=[\n",
-    "                (\"Please stop the music\", \"stop\"),\n",
-    "                (\"play something\", \"play\"),\n",
-    "                (\"play a song\", \"play\"),\n",
-    "                (\"next song\", \"next\"),\n",
-    "            ])\n",
-    "    "
+    "    song: Optional[List[str]] = Field(\n",
+    "        description=\"The song(s) that the user would like to be played.\"\n",
+    "    )\n",
+    "    album: Optional[List[str]] = Field(\n",
+    "        description=\"The album(s) that the user would like to be played.\"\n",
+    "    )\n",
+    "    artist: Optional[List[str]] = Field(\n",
+    "        description=\"The artist(s) whose music the user would like to hear.\",\n",
+    "        examples=[(\"Songs by paul simon\", \"paul simon\")],\n",
+    "    )\n",
+    "    action: Optional[Action] = Field(\n",
+    "        description=\"The action that should be taken; one of `play`, `stop`, `next`, `previous`\",\n",
+    "        examples=[\n",
+    "            (\"Please stop the music\", \"stop\"),\n",
+    "            (\"play something\", \"play\"),\n",
+    "            (\"play a song\", \"play\"),\n",
+    "            (\"next song\", \"next\"),\n",
+    "        ],\n",
+    "    )"
    ]
   },
   {
@@ -138,7 +147,9 @@
    },
    "outputs": [],
    "source": [
-    "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class=\"json\", validator=validator)"
+    "chain = create_extraction_chain(\n",
+    "    llm, schema, encoder_or_encoder_class=\"json\", validator=validator\n",
+    ")"
    ]
   },
   {
@@ -192,7 +203,7 @@
     }
    ],
    "source": [
-    "print(chain.prompt.format_prompt(text='[user input]').to_string())"
+    "print(chain.prompt.format_prompt(text=\"[user input]\").to_string())"
    ]
   },
   {
@@ -204,7 +215,7 @@
    },
    "outputs": [],
    "source": [
-    "chain.predict_and_parse(text=\"stop the music now\")['validated_data']"
+    "chain.predict_and_parse(text=\"stop the music now\")[\"validated_data\"]"
    ]
   },
   {
@@ -227,7 +238,9 @@
     }
    ],
    "source": [
-    "chain.predict_and_parse(text=\"i want to hear yellow submarine by the beatles\")['validated_data']"
+    "chain.predict_and_parse(text=\"i want to hear yellow submarine by the beatles\")[\n",
+    "    \"validated_data\"\n",
+    "]"
    ]
   },
   {
@@ -239,7 +252,7 @@
    },
    "outputs": [],
    "source": [
-    "chain.predict_and_parse(text=\"i want to hear a song\")['validated_data']"
+    "chain.predict_and_parse(text=\"i want to hear a song\")[\"validated_data\"]"
    ]
   },
   {
@@ -262,7 +275,7 @@
     }
    ],
    "source": [
-    "chain.predict_and_parse(text=\"can you play the lion king soundtrack\")['validated_data']"
+    "chain.predict_and_parse(text=\"can you play the lion king soundtrack\")[\"validated_data\"]"
    ]
   },
   {
@@ -285,7 +298,9 @@
     }
    ],
    "source": [
-    "chain.predict_and_parse(text=\"play songs by paul simon and led zeppelin and the doors\")['validated_data']"
+    "chain.predict_and_parse(text=\"play songs by paul simon and led zeppelin and the doors\")[\n",
+    "    \"validated_data\"\n",
+    "]"
    ]
   },
   {
@@ -297,7 +312,9 @@
    },
    "outputs": [],
    "source": [
-    "chain.predict_and_parse(text=\"could you play the previous song again?\")['validated_data']"
+    "chain.predict_and_parse(text=\"could you play the previous song again?\")[\n",
+    "    \"validated_data\"\n",
+    "]"
    ]
   },
   {
@@ -309,7 +326,7 @@
    },
    "outputs": [],
    "source": [
-    "chain.predict_and_parse(text=\"previous\")['validated_data']"
+    "chain.predict_and_parse(text=\"previous\")[\"validated_data\"]"
    ]
   },
   {
@@ -321,7 +338,7 @@
    },
    "outputs": [],
    "source": [
-    "chain.predict_and_parse(text=\"play the song before\")['validated_data']"
+    "chain.predict_and_parse(text=\"play the song before\")[\"validated_data\"]"
    ]
   },
   {
@@ -342,17 +359,25 @@
    "outputs": [],
    "source": [
     "class Player(BaseModel):\n",
-    "    song: List[str] = Field(description='The song(s) that the user would like to be played.') # <-- Note this is NOT Optional\n",
-    "    album: Optional[List[str]] = Field(description='The album(s) that the user would like to be played.')\n",
-    "    artist: Optional[List[str]] = Field(description='The artist(s) whose music the user would like to hear.', examples=[(\"Songs by paul simon\", \"paul simon\")])\n",
-    "    action: Optional[Action] = Field(description='The action that should be taken; one of `play`, `stop`, `next`, `previous`', \n",
-    "                                  examples=[\n",
-    "                (\"Please stop the music\", \"stop\"),\n",
-    "                (\"play something\", \"play\"),\n",
-    "                (\"play a song\", \"play\"),\n",
-    "                (\"next song\", \"next\"),\n",
-    "            ])\n",
-    "    "
+    "    song: List[str] = Field(\n",
+    "        description=\"The song(s) that the user would like to be played.\"\n",
+    "    )  # <-- Note this is NOT Optional\n",
+    "    album: Optional[List[str]] = Field(\n",
+    "        description=\"The album(s) that the user would like to be played.\"\n",
+    "    )\n",
+    "    artist: Optional[List[str]] = Field(\n",
+    "        description=\"The artist(s) whose music the user would like to hear.\",\n",
+    "        examples=[(\"Songs by paul simon\", \"paul simon\")],\n",
+    "    )\n",
+    "    action: Optional[Action] = Field(\n",
+    "        description=\"The action that should be taken; one of `play`, `stop`, `next`, `previous`\",\n",
+    "        examples=[\n",
+    "            (\"Please stop the music\", \"stop\"),\n",
+    "            (\"play something\", \"play\"),\n",
+    "            (\"play a song\", \"play\"),\n",
+    "            (\"next song\", \"next\"),\n",
+    "        ],\n",
+    "    )"
    ]
   },
   {
@@ -365,7 +390,9 @@
    "outputs": [],
    "source": [
     "schema, validator = from_pydantic(Player)\n",
-    "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class=\"json\", validator=validator)"
+    "chain = create_extraction_chain(\n",
+    "    llm, schema, encoder_or_encoder_class=\"json\", validator=validator\n",
+    ")"
    ]
   },
   {
@@ -430,7 +457,9 @@
     }
    ],
    "source": [
-    "chain.predict_and_parse(text=\"i want to hear yellow submarine by the beatles\")['validated_data']"
+    "chain.predict_and_parse(text=\"i want to hear yellow submarine by the beatles\")[\n",
+    "    \"validated_data\"\n",
+    "]"
    ]
   },
   {
@@ -480,8 +509,15 @@
    },
    "outputs": [],
    "source": [
-    "schema, validator = from_pydantic(Person, description='Personal information', many=True, examples=[('Joe is 10 years old', {'name': \"Joe\", \"age\": \"10\"})])\n",
-    "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class=\"csv\", validator=validator)"
+    "schema, validator = from_pydantic(\n",
+    "    Person,\n",
+    "    description=\"Personal information\",\n",
+    "    many=True,\n",
+    "    examples=[(\"Joe is 10 years old\", {\"name\": \"Joe\", \"age\": \"10\"})],\n",
+    ")\n",
+    "chain = create_extraction_chain(\n",
+    "    llm, schema, encoder_or_encoder_class=\"csv\", validator=validator\n",
+    ")"
    ]
   },
   {
@@ -520,7 +556,7 @@
     }
    ],
    "source": [
-    "print(chain.prompt.format_prompt(text='[user input]').to_string())"
+    "print(chain.prompt.format_prompt(text=\"[user input]\").to_string())"
    ]
   },
   {
@@ -543,7 +579,9 @@
     }
    ],
    "source": [
-    "chain.predict_and_parse(text='john is 13 years old. maria is 24 years old')['validated_data']"
+    "chain.predict_and_parse(text=\"john is 13 years old. maria is 24 years old\")[\n",
+    "    \"validated_data\"\n",
+    "]"
    ]
   },
   {
@@ -570,10 +608,13 @@
     "class Person(BaseModel):\n",
     "    name: str = Field(description=\"The person's name\")\n",
     "    age: int = Field(description=\"The age of the person\")\n",
-    "    \n",
-    "    \n",
+    "\n",
+    "\n",
     "class Root(BaseModel):\n",
-    "    people: List[Person] = Field(description='Personal information', examples=[('John was 23 years old', {'name': 'John', 'age': 23})])"
+    "    people: List[Person] = Field(\n",
+    "        description=\"Personal information\",\n",
+    "        examples=[(\"John was 23 years old\", {\"name\": \"John\", \"age\": 23})],\n",
+    "    )"
    ]
   },
   {
@@ -593,8 +634,10 @@
    },
    "outputs": [],
    "source": [
-    "schema, validator = from_pydantic(Root, description='Personal information', many=False)\n",
-    "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class=\"json\", validator=validator)"
+    "schema, validator = from_pydantic(Root, description=\"Personal information\", many=False)\n",
+    "chain = create_extraction_chain(\n",
+    "    llm, schema, encoder_or_encoder_class=\"json\", validator=validator\n",
+    ")"
    ]
   },
   {
@@ -621,7 +664,9 @@
     }
    ],
    "source": [
-    "chain.predict_and_parse(text=\"My name is tom and i am 23 years old. Her name is Jessica and she is 75 years old.\")"
+    "chain.predict_and_parse(\n",
+    "    text=\"My name is tom and i am 23 years old. Her name is Jessica and she is 75 years old.\"\n",
+    ")"
    ]
   },
   {
@@ -659,7 +704,7 @@
     }
    ],
    "source": [
-    "print(chain.prompt.format_prompt(text='[user input]').to_string())"
+    "print(chain.prompt.format_prompt(text=\"[user input]\").to_string())"
    ]
   },
   {
@@ -672,19 +717,35 @@
    "outputs": [],
    "source": [
     "class Pet(BaseModel):\n",
-    "    name: str = Field(description='the name of the pet')\n",
-    "    species: Optional[str] = Field(description='The species of the pet; e.g., dog or cat')\n",
-    "    age: Optional[int] = Field(description='The number of the age; e.g.,')\n",
-    "    age_unit: Optional[str] = Field(description='The unit of the age; e.g., days or weeks')\n",
+    "    name: str = Field(description=\"the name of the pet\")\n",
+    "    species: Optional[str] = Field(\n",
+    "        description=\"The species of the pet; e.g., dog or cat\"\n",
+    "    )\n",
+    "    age: Optional[int] = Field(description=\"The number of the age; e.g.,\")\n",
+    "    age_unit: Optional[str] = Field(\n",
+    "        description=\"The unit of the age; e.g., days or weeks\"\n",
+    "    )\n",
+    "\n",
     "\n",
     "class Person(BaseModel):\n",
     "    name: str = Field(description=\"The person's name\")\n",
     "    age: Optional[int] = Field(description=\"The age of the person\")\n",
-    "    pets: List[Pet] = Field(description='The pets owned by the person', examples=[('he had a dog by the name of charles that was 5 days old', {'name': 'dog', 'species': 'dog', 'age': '5', 'age_unit': 'days'})])\n",
-    "    \n",
-    "    \n",
+    "    pets: List[Pet] = Field(\n",
+    "        description=\"The pets owned by the person\",\n",
+    "        examples=[\n",
+    "            (\n",
+    "                \"he had a dog by the name of charles that was 5 days old\",\n",
+    "                {\"name\": \"dog\", \"species\": \"dog\", \"age\": \"5\", \"age_unit\": \"days\"},\n",
+    "            )\n",
+    "        ],\n",
+    "    )\n",
+    "\n",
+    "\n",
     "class Root(BaseModel):\n",
-    "    people: List[Person] = Field(description='Personal information', examples=[('John was 23 years old', {'name': 'John', 'age': 23})])"
+    "    people: List[Person] = Field(\n",
+    "        description=\"Personal information\",\n",
+    "        examples=[(\"John was 23 years old\", {\"name\": \"John\", \"age\": 23})],\n",
+    "    )"
    ]
   },
   {
@@ -696,8 +757,12 @@
    },
    "outputs": [],
    "source": [
-    "schema, validator = from_pydantic(Root, description='Personal information for multiple people', many=False)\n",
-    "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class=\"json\", validator=validator)"
+    "schema, validator = from_pydantic(\n",
+    "    Root, description=\"Personal information for multiple people\", many=False\n",
+    ")\n",
+    "chain = create_extraction_chain(\n",
+    "    llm, schema, encoder_or_encoder_class=\"json\", validator=validator\n",
+    ")"
    ]
   },
   {
@@ -743,7 +808,7 @@
     }
    ],
    "source": [
-    "print(chain.prompt.format_prompt(text='[user input]').to_string())"
+    "print(chain.prompt.format_prompt(text=\"[user input]\").to_string())"
    ]
   },
   {
@@ -755,7 +820,9 @@
    },
    "outputs": [],
    "source": [
-    "m = chain.predict_and_parse(text='Neo had a dog by the name of Tom and a cat by the name of Weeby. Weeby was 23 days old. Julia owned a horse. The horses name was Wind. And he was 7 years old')"
+    "m = chain.predict_and_parse(\n",
+    "    text=\"Neo had a dog by the name of Tom and a cat by the name of Weeby. Weeby was 23 days old. Julia owned a horse. The horses name was Wind. And he was 7 years old\"\n",
+    ")"
    ]
   },
   {
@@ -778,7 +845,7 @@
     }
    ],
    "source": [
-    "m['validated_data']"
+    "m[\"validated_data\"]"
    ]
   }
  ],

--- a/docs/source/validation.ipynb
+++ b/docs/source/validation.ipynb
@@ -7,7 +7,11 @@
    "source": [
     "# Validation\n",
     "\n",
-    "Here, we'll see how to use pydantic to specify the schema and validate the results."
+    "Here, we'll see how to use pydantic to specify the schema and validate the results.\n",
+    "\n",
+    "**ATTENTION** Validation does *NOT* imply that extraction was correct. Validation only implies that the\n",
+    "data was returned in the correct shape and meets all validation criteria. This doesn't mean\n",
+    "that the LLM didn't make some up information!"
    ]
   },
   {
@@ -39,6 +43,7 @@
    },
    "outputs": [],
    "source": [
+    "import enum\n",
     "from langchain.chat_models import ChatOpenAI\n",
     "from kor import create_extraction_chain, Object, Text, Number\n",
     "import pydantic\n",
@@ -77,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 4,
    "id": "fface268-cda5-430e-a0dc-c354ee4cfe2f",
    "metadata": {
     "tags": []
@@ -106,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 5,
    "id": "4fe1ec70-1428-4433-acac-c190674a666e",
    "metadata": {
     "tags": []
@@ -126,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 6,
    "id": "ff9ad27f-7a81-4123-8d0b-1e14802df67e",
    "metadata": {
     "tags": []
@@ -146,30 +151,65 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
-   "id": "760baa5f-9368-4b5a-abc0-6ac65c34b7a7",
+   "execution_count": 7,
+   "id": "248fa47a-18b5-414f-a656-31c88f7a8dc4",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "MusicRequest(song=None, album=None, artist=None, action=<Action.stop: 'stop'>)"
-      ]
-     },
-     "execution_count": 86,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your goal is to extract structured information from the user's input that matches the form described below. When extracting information please make sure it matches the type information exactly. Do not add any attributes that do not appear in the schema shown below.\n",
+      "\n",
+      "```TypeScript\n",
+      "\n",
+      "musicrequest: { // \n",
+      " song: Array<string> // The song(s) that the user would like to be played.\n",
+      " album: Array<string> // The album(s) that the user would like to be played.\n",
+      " artist: Array<string> // The artist(s) whose music the user would like to hear.\n",
+      " action: \"play\" | \"stop\" | \"previous\" | \"next\" // The action that should be taken; one of `play`, `stop`, `next`, `previous`\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "\n",
+      "Please output the extracted information in JSON format. Do not output anything except for the extracted information. Do not add any clarifying information. Do not add any fields that are not in the schema. If the text contains attributes that do not appear in the schema, please ignore them. All output must be in JSON format and follow the schema specified above. Wrap the JSON in <json> tags.\n",
+      "\n",
+      "Input: Songs by paul simon\n",
+      "Output: <json>{\"musicrequest\": {\"artist\": [\"paul simon\"]}}</json>\n",
+      "Input: Please stop the music\n",
+      "Output: <json>{\"musicrequest\": \"stop\"}</json>\n",
+      "Input: play something\n",
+      "Output: <json>{\"musicrequest\": \"play\"}</json>\n",
+      "Input: play a song\n",
+      "Output: <json>{\"musicrequest\": \"play\"}</json>\n",
+      "Input: next song\n",
+      "Output: <json>{\"musicrequest\": \"next\"}</json>\n",
+      "Input: [user input]\n",
+      "Output:\n"
+     ]
     }
    ],
+   "source": [
+    "print(chain.prompt.format_prompt(text='[user input]').to_string())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "760baa5f-9368-4b5a-abc0-6ac65c34b7a7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
    "source": [
     "chain.predict_and_parse(text=\"stop the music now\")['validated_data']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 9,
    "id": "593b106a-72e7-4c86-82a8-f9630a3bfabb",
    "metadata": {
     "tags": []
@@ -178,10 +218,10 @@
     {
      "data": {
       "text/plain": [
-       "MusicRequest(song=['yellow submarine'], album=None, artist=['the beatles'], action=<Action.play: 'play'>)"
+       "MusicRequest(song=['yellow submarine'], album=None, artist=['beatles'], action=None)"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -192,30 +232,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 10,
    "id": "462303c0-e83a-4e39-86cd-cab6875b40ef",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "MusicRequest(song=None, album=None, artist=None, action=<Action.play: 'play'>)"
-      ]
-     },
-     "execution_count": 88,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "chain.predict_and_parse(text=\"i want to hear a song\")['validated_data']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 11,
    "id": "02c7f1e5-1c8d-4e9f-82e6-c37a41d6de14",
    "metadata": {
     "tags": []
@@ -224,10 +253,10 @@
     {
      "data": {
       "text/plain": [
-       "MusicRequest(song=None, album=['the lion king soundtrack'], artist=None, action=<Action.play: 'play'>)"
+       "MusicRequest(song=None, album=['lion king soundtrack'], artist=None, action=<Action.play: 'play'>)"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -238,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 12,
    "id": "7a6d918c-53fe-426b-b37e-eec2abb8a704",
    "metadata": {
     "tags": []
@@ -247,10 +276,10 @@
     {
      "data": {
       "text/plain": [
-       "MusicRequest(song=None, album=None, artist=['paul simon', 'led zeppelin', 'the doors'], action=<Action.play: 'play'>)"
+       "MusicRequest(song=None, album=None, artist=['paul simon', 'led zeppelin', 'the doors'], action=None)"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -261,69 +290,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 13,
    "id": "b18acf0a-d99e-48de-ace5-fb01bded5a41",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "MusicRequest(song=None, album=None, artist=None, action=<Action.previous: 'previous'>)"
-      ]
-     },
-     "execution_count": 91,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "chain.predict_and_parse(text=\"could you play the previous song again?\")['validated_data']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 14,
    "id": "8c5c06b5-7f3a-416d-a809-19004cb14750",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "MusicRequest(song=None, album=None, artist=None, action=<Action.previous: 'previous'>)"
-      ]
-     },
-     "execution_count": 92,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "chain.predict_and_parse(text=\"previous\")['validated_data']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 15,
    "id": "03f33a42-e1c9-4bc2-a6b4-15d3f3c5ce32",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "MusicRequest(song=None, album=None, artist=None, action=<Action.previous: 'previous'>)"
-      ]
-     },
-     "execution_count": 94,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "chain.predict_and_parse(text=\"play the song before\")['validated_data']"
    ]
@@ -338,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 16,
    "id": "f779d4a2-ddb3-49c4-86cf-d9537b6ca6d4",
    "metadata": {
     "tags": []
@@ -361,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 17,
    "id": "38979da3-13aa-4e34-b11c-3656d7e3b4f6",
    "metadata": {
     "tags": []
@@ -390,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 18,
    "id": "d594eb6e-02a0-4774-9dca-421db192372d",
    "metadata": {
     "tags": []
@@ -399,13 +395,13 @@
     {
      "data": {
       "text/plain": [
-       "{'data': {'player': {'action': 'stop'}},\n",
-       " 'raw': '<json>{\"player\": {\"action\": \"stop\"}}</json>',\n",
-       " 'errors': [ValidationError(model='Player', errors=[{'loc': ('song',), 'msg': 'field required', 'type': 'value_error.missing'}])],\n",
+       "{'data': {'player': 'stop'},\n",
+       " 'raw': '<json>{\"player\": \"stop\"}</json>',\n",
+       " 'errors': [ValidationError(model='Player', errors=[{'loc': ('__root__',), 'msg': 'Player expected dict not str', 'type': 'type_error'}])],\n",
        " 'validated_data': None}"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -416,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 19,
    "id": "672f9908-c6b7-47cf-8c82-03b0e5b8fa84",
    "metadata": {
     "tags": []
@@ -425,10 +421,10 @@
     {
      "data": {
       "text/plain": [
-       "Player(song=['yellow submarine'], album=None, artist=['the beatles'], action=<Action.play: 'play'>)"
+       "Player(song=['yellow submarine'], album=None, artist=['the beatles'], action=None)"
       ]
      },
-     "execution_count": 99,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -463,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 20,
    "id": "cd9dffbe-82bf-4d1f-9b0a-3ec2c58b63d6",
    "metadata": {
     "tags": []
@@ -477,7 +473,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 21,
    "id": "f859b6e1-c2d8-48e0-af17-2ffb286bffe9",
    "metadata": {
     "tags": []
@@ -490,7 +486,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 22,
    "id": "af6c6339-81db-482b-9507-31f41d2fa489",
    "metadata": {
     "tags": []
@@ -529,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 23,
    "id": "837a08c2-8de0-448a-9984-0cf19a73d4a3",
    "metadata": {
     "tags": []
@@ -541,7 +537,7 @@
        "[Person(name='john', age=13), Person(name='maria', age=24)]"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -555,16 +551,16 @@
    "id": "7622135e-3a2e-41b2-a99f-980e5dd9f804",
    "metadata": {},
    "source": [
-    "## JSON Encoder\n",
+    "## Complex Structure\n",
     "\n",
-    "A JSON encoder can handle more complex structure.\n",
+    "To serialize more complex structures, use the JSON encoder.\n",
     "\n",
-    "So the following alternative works..."
+    "So for the example, above the following alternative works:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 24,
    "id": "ee92ae5e-52e9-4405-9718-be71d25ce412",
    "metadata": {
     "tags": []
@@ -581,21 +577,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b1c618c8-adab-48bd-bc5d-45dc5adb1dbb",
+   "metadata": {},
+   "source": [
+    "** NOTE ** Using a Root container and `many` = `False`"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 25,
    "id": "7464aab0-45fb-4e22-bed4-b695c7f60629",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "schema, validator = from_pydantic(Person, description='Personal information', many=True, examples=[('Joe is 10 years old', {'name': \"Joe\", \"age\": \"10\"})])\n",
+    "schema, validator = from_pydantic(Root, description='Personal information', many=False)\n",
     "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class=\"json\", validator=validator)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 26,
    "id": "8becd13d-bd23-4d37-8fd3-7548a7fe51c1",
    "metadata": {
     "tags": []
@@ -604,15 +608,14 @@
     {
      "data": {
       "text/plain": [
-       "{'data': {'person': [{'name': 'tom', 'age': '23'},\n",
-       "   {'name': 'Jessica', 'age': '75'}]},\n",
-       " 'raw': '<json>{\"person\": [{\"name\": \"tom\", \"age\": \"23\"}, {\"name\": \"Jessica\", \"age\": \"75\"}]}</json>',\n",
+       "{'data': {'root': {'people': [{'name': 'tom', 'age': 23},\n",
+       "    {'name': 'Jessica', 'age': 75}]}},\n",
+       " 'raw': '<json>{\"root\": {\"people\": [{\"name\": \"tom\", \"age\": 23}, {\"name\": \"Jessica\", \"age\": 75}]}}</json>',\n",
        " 'errors': [],\n",
-       " 'validated_data': [Person(name='tom', age=23),\n",
-       "  Person(name='Jessica', age=75)]}"
+       " 'validated_data': Root(people=[Person(name='tom', age=23), Person(name='Jessica', age=75)])}"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -623,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 27,
    "id": "7ea06fe0-104b-487a-ab78-cd23de66ec88",
    "metadata": {
     "tags": []
@@ -637,17 +640,19 @@
       "\n",
       "```TypeScript\n",
       "\n",
-      "person: Array<{ // Personal information\n",
-      " name: string // The person's name\n",
-      " age: number // The age of the person\n",
-      "}>\n",
+      "root: { // Personal information\n",
+      " people: Array<{ // Personal information\n",
+      "  name: string // The person's name\n",
+      "  age: number // The age of the person\n",
+      " }>\n",
+      "}\n",
       "```\n",
       "\n",
       "\n",
       "Please output the extracted information in JSON format. Do not output anything except for the extracted information. Do not add any clarifying information. Do not add any fields that are not in the schema. If the text contains attributes that do not appear in the schema, please ignore them. All output must be in JSON format and follow the schema specified above. Wrap the JSON in <json> tags.\n",
       "\n",
-      "Input: Joe is 10 years old\n",
-      "Output: <json>{\"person\": [{\"name\": \"Joe\", \"age\": \"10\"}]}</json>\n",
+      "Input: John was 23 years old\n",
+      "Output: <json>{\"root\": {\"people\": [{\"name\": \"John\", \"age\": 23}]}}</json>\n",
       "Input: [user input]\n",
       "Output:\n"
      ]
@@ -655,6 +660,125 @@
    ],
    "source": [
     "print(chain.prompt.format_prompt(text='[user input]').to_string())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "38245cd6-e188-40c9-a940-184da8755983",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "class Pet(BaseModel):\n",
+    "    name: str = Field(description='the name of the pet')\n",
+    "    species: Optional[str] = Field(description='The species of the pet; e.g., dog or cat')\n",
+    "    age: Optional[int] = Field(description='The number of the age; e.g.,')\n",
+    "    age_unit: Optional[str] = Field(description='The unit of the age; e.g., days or weeks')\n",
+    "\n",
+    "class Person(BaseModel):\n",
+    "    name: str = Field(description=\"The person's name\")\n",
+    "    age: Optional[int] = Field(description=\"The age of the person\")\n",
+    "    pets: List[Pet] = Field(description='The pets owned by the person', examples=[('he had a dog by the name of charles that was 5 days old', {'name': 'dog', 'species': 'dog', 'age': '5', 'age_unit': 'days'})])\n",
+    "    \n",
+    "    \n",
+    "class Root(BaseModel):\n",
+    "    people: List[Person] = Field(description='Personal information', examples=[('John was 23 years old', {'name': 'John', 'age': 23})])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "236a9510-6f69-4d63-8854-62e2c57380a6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "schema, validator = from_pydantic(Root, description='Personal information for multiple people', many=False)\n",
+    "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class=\"json\", validator=validator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "843e992a-32c5-4382-95ab-33eb3cd7810b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your goal is to extract structured information from the user's input that matches the form described below. When extracting information please make sure it matches the type information exactly. Do not add any attributes that do not appear in the schema shown below.\n",
+      "\n",
+      "```TypeScript\n",
+      "\n",
+      "root: { // Personal information for multiple people\n",
+      " people: Array<{ // Personal information\n",
+      "  name: string // The person's name\n",
+      "  age: number // The age of the person\n",
+      "  pets: Array<{ // The pets owned by the person\n",
+      "   name: string // the name of the pet\n",
+      "   species: string // The species of the pet; e.g., dog or cat\n",
+      "   age: number // The number of the age; e.g.,\n",
+      "   age_unit: string // The unit of the age; e.g., days or weeks\n",
+      "  }>\n",
+      " }>\n",
+      "}\n",
+      "```\n",
+      "\n",
+      "\n",
+      "Please output the extracted information in JSON format. Do not output anything except for the extracted information. Do not add any clarifying information. Do not add any fields that are not in the schema. If the text contains attributes that do not appear in the schema, please ignore them. All output must be in JSON format and follow the schema specified above. Wrap the JSON in <json> tags.\n",
+      "\n",
+      "Input: John was 23 years old\n",
+      "Output: <json>{\"root\": {\"people\": [{\"name\": \"John\", \"age\": 23}]}}</json>\n",
+      "Input: he had a dog by the name of charles that was 5 days old\n",
+      "Output: <json>{\"root\": {\"people\": [{\"pets\": [{\"name\": \"dog\", \"species\": \"dog\", \"age\": \"5\", \"age_unit\": \"days\"}]}]}}</json>\n",
+      "Input: [user input]\n",
+      "Output:\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(chain.prompt.format_prompt(text='[user input]').to_string())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "e34b6194-9a2b-43a1-95c6-2c9930d036ed",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "m = chain.predict_and_parse(text='Neo had a dog by the name of Tom and a cat by the name of Weeby. Weeby was 23 days old. Julia owned a horse. The horses name was Wind. And he was 7 years old')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "5d4aa14c-e503-4871-8f13-db68e5daf817",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Root(people=[Person(name='Neo', age=None, pets=[Pet(name='Tom', species='dog', age=None, age_unit=None), Pet(name='Weeby', species='cat', age=23, age_unit='days')]), Person(name='Julia', age=None, pets=[Pet(name='Wind', species='horse', age=7, age_unit='years')])])"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "m['validated_data']"
    ]
   }
  ],
@@ -674,7 +798,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.1"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/docs/source/validation.ipynb
+++ b/docs/source/validation.ipynb
@@ -1,0 +1,682 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4b3a0584-b52c-4873-abb8-8382e13ff5c0",
+   "metadata": {},
+   "source": [
+    "# Validation\n",
+    "\n",
+    "Here, we'll see how to use pydantic to specify the schema and validate the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0b4597b2-2a43-4491-8830-bf9f79428074",
+   "metadata": {
+    "nbsphinx": "hidden",
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "import sys\n",
+    "\n",
+    "sys.path.insert(0, \"../../\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c719e4fc-3ccf-4633-a787-b2fe0d1eac65",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from langchain.chat_models import ChatOpenAI\n",
+    "from kor import create_extraction_chain, Object, Text, Number\n",
+    "import pydantic\n",
+    "from typing import List\n",
+    "from kor import from_pydantic\n",
+    "from pydantic import BaseModel, Field\n",
+    "from typing import Optional"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f1313c02-d415-4ce6-bff0-3df537cc06c2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "llm = ChatOpenAI(\n",
+    "    model_name=\"gpt-3.5-turbo\",\n",
+    "    temperature=0,\n",
+    "    max_tokens=2000,\n",
+    "    frequency_penalty=0,\n",
+    "    presence_penalty=0,\n",
+    "    top_p=1.0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6ce4726-db5b-49ee-abf7-780fd707be5f",
+   "metadata": {},
+   "source": [
+    "Let's returning to our hypothetical music player API:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "id": "fface268-cda5-430e-a0dc-c354ee4cfe2f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "class Action(enum.Enum):\n",
+    "    play = 'play'\n",
+    "    stop = 'stop'\n",
+    "    previous = 'previous'\n",
+    "    next_ = 'next'\n",
+    "\n",
+    "class MusicRequest(BaseModel):\n",
+    "    song: Optional[List[str]] = Field(description='The song(s) that the user would like to be played.')\n",
+    "    album: Optional[List[str]] = Field(description='The album(s) that the user would like to be played.')\n",
+    "    artist: Optional[List[str]] = Field(description='The artist(s) whose music the user would like to hear.', examples=[(\"Songs by paul simon\", \"paul simon\")])\n",
+    "    action: Optional[Action] = Field(description='The action that should be taken; one of `play`, `stop`, `next`, `previous`', \n",
+    "                                  examples=[\n",
+    "                (\"Please stop the music\", \"stop\"),\n",
+    "                (\"play something\", \"play\"),\n",
+    "                (\"play a song\", \"play\"),\n",
+    "                (\"next song\", \"next\"),\n",
+    "            ])\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "id": "4fe1ec70-1428-4433-acac-c190674a666e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "schema, validator = from_pydantic(MusicRequest)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49029ef7-c084-46f2-9791-6fb731252a9f",
+   "metadata": {},
+   "source": [
+    "**ATTENTION** Use the JSON encoder here rather than the default CSV encoder as it supports nested lists"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "id": "ff9ad27f-7a81-4123-8d0b-1e14802df67e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class=\"json\", validator=validator)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cc3f196-5c63-44ae-bbf3-471c2af47bf8",
+   "metadata": {},
+   "source": [
+    "Let's test it out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "id": "760baa5f-9368-4b5a-abc0-6ac65c34b7a7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=None, album=None, artist=None, action=<Action.stop: 'stop'>)"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text=\"stop the music now\")['validated_data']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "id": "593b106a-72e7-4c86-82a8-f9630a3bfabb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=['yellow submarine'], album=None, artist=['the beatles'], action=<Action.play: 'play'>)"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text=\"i want to hear yellow submarine by the beatles\")['validated_data']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "id": "462303c0-e83a-4e39-86cd-cab6875b40ef",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=None, album=None, artist=None, action=<Action.play: 'play'>)"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text=\"i want to hear a song\")['validated_data']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "id": "02c7f1e5-1c8d-4e9f-82e6-c37a41d6de14",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=None, album=['the lion king soundtrack'], artist=None, action=<Action.play: 'play'>)"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text=\"can you play the lion king soundtrack\")['validated_data']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "id": "7a6d918c-53fe-426b-b37e-eec2abb8a704",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=None, album=None, artist=['paul simon', 'led zeppelin', 'the doors'], action=<Action.play: 'play'>)"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text=\"play songs by paul simon and led zeppelin and the doors\")['validated_data']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "id": "b18acf0a-d99e-48de-ace5-fb01bded5a41",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=None, album=None, artist=None, action=<Action.previous: 'previous'>)"
+      ]
+     },
+     "execution_count": 91,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text=\"could you play the previous song again?\")['validated_data']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "id": "8c5c06b5-7f3a-416d-a809-19004cb14750",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=None, album=None, artist=None, action=<Action.previous: 'previous'>)"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text=\"previous\")['validated_data']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "id": "03f33a42-e1c9-4bc2-a6b4-15d3f3c5ce32",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=None, album=None, artist=None, action=<Action.previous: 'previous'>)"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text=\"play the song before\")['validated_data']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95f22605-a2b0-401e-ac7d-48d97913d535",
+   "metadata": {},
+   "source": [
+    "## Validation in Action"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "f779d4a2-ddb3-49c4-86cf-d9537b6ca6d4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "class Player(BaseModel):\n",
+    "    song: List[str] = Field(description='The song(s) that the user would like to be played.') # <-- Note this is NOT Optional\n",
+    "    album: Optional[List[str]] = Field(description='The album(s) that the user would like to be played.')\n",
+    "    artist: Optional[List[str]] = Field(description='The artist(s) whose music the user would like to hear.', examples=[(\"Songs by paul simon\", \"paul simon\")])\n",
+    "    action: Optional[Action] = Field(description='The action that should be taken; one of `play`, `stop`, `next`, `previous`', \n",
+    "                                  examples=[\n",
+    "                (\"Please stop the music\", \"stop\"),\n",
+    "                (\"play something\", \"play\"),\n",
+    "                (\"play a song\", \"play\"),\n",
+    "                (\"next song\", \"next\"),\n",
+    "            ])\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "id": "38979da3-13aa-4e34-b11c-3656d7e3b4f6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "schema, validator = from_pydantic(Player)\n",
+    "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class=\"json\", validator=validator)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ceaec432-480f-44f0-aad9-9eb8146f0f02",
+   "metadata": {},
+   "source": [
+    "Now the schema expects that a list of songs parsed out in the query."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "229771c7-eb16-4a54-85ac-13f4f0d8c527",
+   "metadata": {},
+   "source": [
+    "### No valid data!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "d594eb6e-02a0-4774-9dca-421db192372d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'data': {'player': {'action': 'stop'}},\n",
+       " 'raw': '<json>{\"player\": {\"action\": \"stop\"}}</json>',\n",
+       " 'errors': [ValidationError(model='Player', errors=[{'loc': ('song',), 'msg': 'field required', 'type': 'value_error.missing'}])],\n",
+       " 'validated_data': None}"
+      ]
+     },
+     "execution_count": 98,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text=\"stop the music now\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "id": "672f9908-c6b7-47cf-8c82-03b0e5b8fa84",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Player(song=['yellow submarine'], album=None, artist=['the beatles'], action=<Action.play: 'play'>)"
+      ]
+     },
+     "execution_count": 99,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text=\"i want to hear yellow submarine by the beatles\")['validated_data']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02559660-20a4-4fce-83a4-2e3b68794f19",
+   "metadata": {},
+   "source": [
+    "## Validating Collections\n",
+    "\n",
+    "Currently, there are a few gotchyas when modeling collections that depend on the encoder."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3da8c0fe-3765-4a6e-8925-85806e9500cc",
+   "metadata": {},
+   "source": [
+    "### CSV Encoder\n",
+    "\n",
+    "A CSV encoder is expected to work best when encoding a list of records.\n",
+    "\n",
+    "At the moment, the CSV encoder doesn't handle embedded lists or objects. \n",
+    "\n",
+    "(This works with either JSON or CSV.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "id": "cd9dffbe-82bf-4d1f-9b0a-3ec2c58b63d6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "class Person(BaseModel):\n",
+    "    name: str = Field(description=\"The person's name\")\n",
+    "    age: int = Field(description=\"The age of the person\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "id": "f859b6e1-c2d8-48e0-af17-2ffb286bffe9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "schema, validator = from_pydantic(Person, description='Personal information', many=True, examples=[('Joe is 10 years old', {'name': \"Joe\", \"age\": \"10\"})])\n",
+    "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class=\"csv\", validator=validator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 102,
+   "id": "af6c6339-81db-482b-9507-31f41d2fa489",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your goal is to extract structured information from the user's input that matches the form described below. When extracting information please make sure it matches the type information exactly. Do not add any attributes that do not appear in the schema shown below.\n",
+      "\n",
+      "```TypeScript\n",
+      "\n",
+      "person: Array<{ // Personal information\n",
+      " name: string // The person's name\n",
+      " age: number // The age of the person\n",
+      "}>\n",
+      "```\n",
+      "\n",
+      "\n",
+      "Please output the extracted information in CSV format in Excel dialect. Please use a | as the delimiter. \n",
+      " Do NOT add any clarifying information. Output MUST follow the schema above. Do NOT add any additional columns that do not appear in the schema.\n",
+      "\n",
+      "Input: Joe is 10 years old\n",
+      "Output: name|age\n",
+      "Joe|10\n",
+      "\n",
+      "Input: [user input]\n",
+      "Output:\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(chain.prompt.format_prompt(text='[user input]').to_string())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "id": "837a08c2-8de0-448a-9984-0cf19a73d4a3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Person(name='john', age=13), Person(name='maria', age=24)]"
+      ]
+     },
+     "execution_count": 103,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text='john is 13 years old. maria is 24 years old')['validated_data']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7622135e-3a2e-41b2-a99f-980e5dd9f804",
+   "metadata": {},
+   "source": [
+    "## JSON Encoder\n",
+    "\n",
+    "A JSON encoder can handle more complex structure.\n",
+    "\n",
+    "So the following alternative works..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "id": "ee92ae5e-52e9-4405-9718-be71d25ce412",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "class Person(BaseModel):\n",
+    "    name: str = Field(description=\"The person's name\")\n",
+    "    age: int = Field(description=\"The age of the person\")\n",
+    "    \n",
+    "    \n",
+    "class Root(BaseModel):\n",
+    "    people: List[Person] = Field(description='Personal information', examples=[('John was 23 years old', {'name': 'John', 'age': 23})])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "id": "7464aab0-45fb-4e22-bed4-b695c7f60629",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "schema, validator = from_pydantic(Person, description='Personal information', many=True, examples=[('Joe is 10 years old', {'name': \"Joe\", \"age\": \"10\"})])\n",
+    "chain = create_extraction_chain(llm, schema, encoder_or_encoder_class=\"json\", validator=validator)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "id": "8becd13d-bd23-4d37-8fd3-7548a7fe51c1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'data': {'person': [{'name': 'tom', 'age': '23'},\n",
+       "   {'name': 'Jessica', 'age': '75'}]},\n",
+       " 'raw': '<json>{\"person\": [{\"name\": \"tom\", \"age\": \"23\"}, {\"name\": \"Jessica\", \"age\": \"75\"}]}</json>',\n",
+       " 'errors': [],\n",
+       " 'validated_data': [Person(name='tom', age=23),\n",
+       "  Person(name='Jessica', age=75)]}"
+      ]
+     },
+     "execution_count": 106,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "chain.predict_and_parse(text=\"My name is tom and i am 23 years old. Her name is Jessica and she is 75 years old.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "id": "7ea06fe0-104b-487a-ab78-cd23de66ec88",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your goal is to extract structured information from the user's input that matches the form described below. When extracting information please make sure it matches the type information exactly. Do not add any attributes that do not appear in the schema shown below.\n",
+      "\n",
+      "```TypeScript\n",
+      "\n",
+      "person: Array<{ // Personal information\n",
+      " name: string // The person's name\n",
+      " age: number // The age of the person\n",
+      "}>\n",
+      "```\n",
+      "\n",
+      "\n",
+      "Please output the extracted information in JSON format. Do not output anything except for the extracted information. Do not add any clarifying information. Do not add any fields that are not in the schema. If the text contains attributes that do not appear in the schema, please ignore them. All output must be in JSON format and follow the schema specified above. Wrap the JSON in <json> tags.\n",
+      "\n",
+      "Input: Joe is 10 years old\n",
+      "Output: <json>{\"person\": [{\"name\": \"Joe\", \"age\": \"10\"}]}</json>\n",
+      "Input: [user input]\n",
+      "Output:\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(chain.prompt.format_prompt(text='[user input]').to_string())"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/validation.ipynb
+++ b/docs/source/validation.ipynb
@@ -190,13 +190,13 @@
       "Input: Songs by paul simon\n",
       "Output: <json>{\"musicrequest\": {\"artist\": [\"paul simon\"]}}</json>\n",
       "Input: Please stop the music\n",
-      "Output: <json>{\"musicrequest\": \"stop\"}</json>\n",
+      "Output: <json>{\"musicrequest\": {\"action\": \"stop\"}}</json>\n",
       "Input: play something\n",
-      "Output: <json>{\"musicrequest\": \"play\"}</json>\n",
+      "Output: <json>{\"musicrequest\": {\"action\": \"play\"}}</json>\n",
       "Input: play a song\n",
-      "Output: <json>{\"musicrequest\": \"play\"}</json>\n",
+      "Output: <json>{\"musicrequest\": {\"action\": \"play\"}}</json>\n",
       "Input: next song\n",
-      "Output: <json>{\"musicrequest\": \"next\"}</json>\n",
+      "Output: <json>{\"musicrequest\": {\"action\": \"next\"}}</json>\n",
       "Input: [user input]\n",
       "Output:\n"
      ]
@@ -213,7 +213,18 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=None, album=None, artist=None, action=<Action.stop: 'stop'>)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "chain.predict_and_parse(text=\"stop the music now\")[\"validated_data\"]"
    ]
@@ -229,7 +240,7 @@
     {
      "data": {
       "text/plain": [
-       "MusicRequest(song=['yellow submarine'], album=None, artist=['beatles'], action=None)"
+       "MusicRequest(song=['yellow submarine'], album=None, artist=['the beatles'], action=None)"
       ]
      },
      "execution_count": 9,
@@ -246,13 +257,26 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "462303c0-e83a-4e39-86cd-cab6875b40ef",
+   "id": "8d728835-2e3e-40d3-8bba-2cd4bd4ec789",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=['goliath'], album=None, artist=['smith&thell'], action=<Action.play: 'play'>)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "chain.predict_and_parse(text=\"i want to hear a song\")[\"validated_data\"]"
+    "chain.predict_and_parse(text=\"play goliath by smith&thell\")[\n",
+    "    \"validated_data\"\n",
+    "]"
    ]
   },
   {
@@ -266,7 +290,7 @@
     {
      "data": {
       "text/plain": [
-       "MusicRequest(song=None, album=['lion king soundtrack'], artist=None, action=<Action.play: 'play'>)"
+       "MusicRequest(song=None, album=['lion king soundtrack'], artist=None, action=None)"
       ]
      },
      "execution_count": 11,
@@ -305,12 +329,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "b18acf0a-d99e-48de-ace5-fb01bded5a41",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=None, album=None, artist=None, action=<Action.previous: 'previous'>)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "chain.predict_and_parse(text=\"could you play the previous song again?\")[\n",
     "    \"validated_data\"\n",
@@ -319,24 +354,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "8c5c06b5-7f3a-416d-a809-19004cb14750",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=None, album=None, artist=None, action=<Action.previous: 'previous'>)"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "chain.predict_and_parse(text=\"previous\")[\"validated_data\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "03f33a42-e1c9-4bc2-a6b4-15d3f3c5ce32",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MusicRequest(song=None, album=None, artist=None, action=<Action.previous: 'previous'>)"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "chain.predict_and_parse(text=\"play the song before\")[\"validated_data\"]"
    ]
@@ -351,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "f779d4a2-ddb3-49c4-86cf-d9537b6ca6d4",
    "metadata": {
     "tags": []
@@ -382,7 +439,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "38979da3-13aa-4e34-b11c-3656d7e3b4f6",
    "metadata": {
     "tags": []
@@ -413,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "d594eb6e-02a0-4774-9dca-421db192372d",
    "metadata": {
     "tags": []
@@ -422,13 +479,13 @@
     {
      "data": {
       "text/plain": [
-       "{'data': {'player': 'stop'},\n",
-       " 'raw': '<json>{\"player\": \"stop\"}</json>',\n",
-       " 'errors': [ValidationError(model='Player', errors=[{'loc': ('__root__',), 'msg': 'Player expected dict not str', 'type': 'type_error'}])],\n",
+       "{'data': {'player': {'action': 'stop'}},\n",
+       " 'raw': '<json>{\"player\": {\"action\": \"stop\"}}</json>',\n",
+       " 'errors': [ValidationError(model='Player', errors=[{'loc': ('song',), 'msg': 'field required', 'type': 'value_error.missing'}])],\n",
        " 'validated_data': None}"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -439,7 +496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "id": "672f9908-c6b7-47cf-8c82-03b0e5b8fa84",
    "metadata": {
     "tags": []
@@ -448,10 +505,10 @@
     {
      "data": {
       "text/plain": [
-       "Player(song=['yellow submarine'], album=None, artist=['the beatles'], action=None)"
+       "Player(song=['yellow submarine'], album=None, artist=['the beatles'], action=<Action.play: 'play'>)"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -488,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "id": "cd9dffbe-82bf-4d1f-9b0a-3ec2c58b63d6",
    "metadata": {
     "tags": []
@@ -502,7 +559,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "id": "f859b6e1-c2d8-48e0-af17-2ffb286bffe9",
    "metadata": {
     "tags": []
@@ -522,7 +579,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "id": "af6c6339-81db-482b-9507-31f41d2fa489",
    "metadata": {
     "tags": []
@@ -561,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "id": "837a08c2-8de0-448a-9984-0cf19a73d4a3",
    "metadata": {
     "tags": []
@@ -573,7 +630,7 @@
        "[Person(name='john', age=13), Person(name='maria', age=24)]"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -598,7 +655,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "id": "ee92ae5e-52e9-4405-9718-be71d25ce412",
    "metadata": {
     "tags": []
@@ -627,7 +684,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "id": "7464aab0-45fb-4e22-bed4-b695c7f60629",
    "metadata": {
     "tags": []
@@ -642,7 +699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "id": "8becd13d-bd23-4d37-8fd3-7548a7fe51c1",
    "metadata": {
     "tags": []
@@ -658,7 +715,7 @@
        " 'validated_data': Root(people=[Person(name='tom', age=23), Person(name='Jessica', age=75)])}"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -671,7 +728,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "id": "7ea06fe0-104b-487a-ab78-cd23de66ec88",
    "metadata": {
     "tags": []
@@ -709,7 +766,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 27,
    "id": "38245cd6-e188-40c9-a940-184da8755983",
    "metadata": {
     "tags": []
@@ -750,7 +807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "id": "236a9510-6f69-4d63-8854-62e2c57380a6",
    "metadata": {
     "tags": []
@@ -767,7 +824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "id": "843e992a-32c5-4382-95ab-33eb3cd7810b",
    "metadata": {
     "tags": []
@@ -813,7 +870,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "id": "e34b6194-9a2b-43a1-95c6-2c9930d036ed",
    "metadata": {
     "tags": []
@@ -827,7 +884,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "id": "5d4aa14c-e503-4871-8f13-db68e5daf817",
    "metadata": {
     "tags": []
@@ -839,7 +896,7 @@
        "Root(people=[Person(name='Neo', age=None, pets=[Pet(name='Tom', species='dog', age=None, age_unit=None), Pet(name='Weeby', species='cat', age=23, age_unit='days')]), Person(name='Julia', age=None, pets=[Pet(name='Wind', species='horse', age=7, age_unit='years')])])"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/kor/__init__.py
+++ b/kor/__init__.py
@@ -1,3 +1,4 @@
+from .adapters import from_pydantic
 from .encoders import CSVEncoder, JSONEncoder, XMLEncoder
 from .extraction import create_extraction_chain
 from .nodes import Number, Object, Option, Selection, Text
@@ -6,7 +7,6 @@ from .type_descriptors import (
     TypeDescriptor,
     TypeScriptDescriptor,
 )
-from .adapters import from_pydantic
 
 __all__ = (
     "BulletPointDescriptor",

--- a/kor/__init__.py
+++ b/kor/__init__.py
@@ -6,18 +6,20 @@ from .type_descriptors import (
     TypeDescriptor,
     TypeScriptDescriptor,
 )
+from .adapters import from_pydantic
 
 __all__ = (
-    "Text",
-    "Object",
-    "Number",
-    "Selection",
-    "Option",
+    "BulletPointDescriptor",
     "create_extraction_chain",
+    "CSVEncoder",
+    "from_pydantic",
+    "JSONEncoder",
+    "Number",
+    "Object",
+    "Option",
+    "Selection",
+    "Text",
     "TypeDescriptor",
     "TypeScriptDescriptor",
-    "BulletPointDescriptor",
-    "CSVEncoder",
     "XMLEncoder",
-    "JSONEncoder",
 )

--- a/kor/adapters.py
+++ b/kor/adapters.py
@@ -1,9 +1,10 @@
 """Adapters to convert from validation frameworks to Kor internal representation."""
-from pydantic import BaseModel
-from typing import Type, Sequence, Tuple, Any, Dict, get_origin, Optional
+from typing import Any, Dict, Optional, Sequence, Tuple, Type, get_origin
 
-from .nodes import Object, Text, Number
-from .validators import Validator, PydanticValidator
+from pydantic import BaseModel
+
+from .nodes import Number, Object, Text
+from .validators import PydanticValidator, Validator
 
 
 def _translate_pydantic_to_kor(

--- a/kor/adapters.py
+++ b/kor/adapters.py
@@ -1,18 +1,34 @@
 """Adapters to convert from validation frameworks to Kor internal representation."""
 from pydantic import BaseModel
-from typing import Type, Sequence, Tuple, Any, Dict, get_origin
+from typing import Type, Sequence, Tuple, Any, Dict, get_origin, Optional
 
 from .nodes import Object, Text, Number
+from .validators import Validator, PydanticValidator
 
 
-def _convert_pydantic_internal(
+# PUBLIC API
+
+
+def translate_pydantic_to_kor(
     model_class: Type[BaseModel],
     *,
+    name: Optional[str] = None,
     description: str = "",
     examples: Sequence[Tuple[str, Dict[str, Any]]] = tuple(),
     many: bool = False,
 ) -> Object:
-    """Same as main API but many is now controllable."""
+    """Convert a pydantic model to Kor internal representation.
+
+    Args:
+        model_class: The pydantic model class to convert.
+        description: The description of the model.
+        examples: A sequence of examples of the model.
+        many: Whether the model is a list of models.
+
+    Returns:
+        The Kor internal representation of the model.
+    """
+
     attributes = []
     for field_name, field in model_class.__fields__.items():
         field_info = field.field_info
@@ -27,31 +43,30 @@ def _convert_pydantic_internal(
         type_ = field.type_
         field_many = get_origin(field.outer_type_) is list
         if issubclass(type_, BaseModel):
-            attr = _convert_pydantic_internal(
+            attribute = translate_pydantic_to_kor(
                 type_,
                 description=field_description,
                 examples=field_examples,
                 many=field_many,
-            )
-        elif isinstance(type_, (int, float)):
-            attr = Number(
-                id=field.name,
-                examples=field_examples,
-                description=field_description,
-                many=field_many,
+                name=field_name,
             )
         else:
-            attr = Text(
-                id=field.name,
+            if isinstance(type_, (int, float)):
+                node_class = Number
+            else:
+                node_class = Text
+
+            attribute = node_class(
+                id=field_name,
                 examples=field_examples,
                 description=field_description,
                 many=field_many,
             )
 
-        attributes.append(attr)
+        attributes.append(attribute)
 
     return Object(
-        id=model_class.__name__.lower(),
+        id=name or model_class.__name__.lower(),
         attributes=attributes,
         description=description,
         examples=examples,
@@ -59,22 +74,19 @@ def _convert_pydantic_internal(
     )
 
 
-# PUBLIC API
-
-
-def convert_pydantic(
+def foo(
     model_class: Type[BaseModel],
     *,
     description: str = "",
     examples: Sequence[Tuple[str, Dict[str, Any]]] = tuple(),
-) -> Object:
-    """Convert a pydantic model to Kor internal representation.
-
-    Args:
-        model_class: The pydantic model class to convert.
-        description: The description of the model.
-        examples: A sequence of examples of the model.
-    """
-    return _convert_pydantic_internal(
-        model_class, description=description, examples=examples
+    many: bool = False,
+) -> Tuple[Object, Validator]:
+    """Convert a pydantic model to Kor internal representation."""
+    validator = PydanticValidator(model_class, many)
+    schema = translate_pydantic_to_kor(
+        model_class,
+        description=description,
+        examples=examples,
+        many=many,
     )
+    return schema, validator

--- a/kor/adapters.py
+++ b/kor/adapters.py
@@ -52,7 +52,15 @@ def _translate_pydantic_to_kor(
                 name=field_name,
             )
         else:
-            if issubclass(type_, (int, float)):
+            # Precedence matters here since bool is a subclass of int
+            if issubclass(type_, bool):
+                attribute = Text(
+                    id=field_name,
+                    examples=field_examples,
+                    description=field_description,
+                    many=field_many,
+                )
+            elif issubclass(type_, (int, float)):
                 attribute = Number(
                     id=field_name,
                     examples=field_examples,

--- a/kor/adapters.py
+++ b/kor/adapters.py
@@ -1,27 +1,80 @@
+"""Adapters to convert from validation frameworks to Kor internal representation."""
 from pydantic import BaseModel
-from typing import Type, Sequence, Tuple
+from typing import Type, Sequence, Tuple, Any, Dict, get_origin
 
 from .nodes import Object, Text, Number
 
 
-def convert_pydantic(
-    model_class: Type[BaseModel], examples: Sequence[Tuple[str, str]] = tuple()
+def _convert_pydantic_internal(
+    model_class: Type[BaseModel],
+    *,
+    description: str = "",
+    examples: Sequence[Tuple[str, Dict[str, Any]]] = tuple(),
+    many: bool = False,
 ) -> Object:
-    """Convert a pydantic model to a kor Object."""
+    """Same as main API but many is now controllable."""
     attributes = []
     for field_name, field in model_class.__fields__.items():
-        type_ = field.type_
-        if issubclass(type_, BaseModel):
-            attr = convert_pydantic(type_)
-        elif isinstance(type_, (int, float)):
-            attr = Number(id=field.name)
+        field_info = field.field_info
+        extra = field_info.extra
+        if "examples" in extra:
+            field_examples = extra["examples"]
         else:
-            attr = Text(id=field.name)
+            field_examples = tuple()
+
+        field_description = field_info.description or ""
+
+        type_ = field.type_
+        field_many = get_origin(field.outer_type_) is list
+        if issubclass(type_, BaseModel):
+            attr = _convert_pydantic_internal(
+                type_,
+                description=field_description,
+                examples=field_examples,
+                many=field_many,
+            )
+        elif isinstance(type_, (int, float)):
+            attr = Number(
+                id=field.name,
+                examples=field_examples,
+                description=field_description,
+                many=field_many,
+            )
+        else:
+            attr = Text(
+                id=field.name,
+                examples=field_examples,
+                description=field_description,
+                many=field_many,
+            )
 
         attributes.append(attr)
 
     return Object(
-        id=model_class.__class__.__name__.lower(),
+        id=model_class.__name__.lower(),
         attributes=attributes,
+        description=description,
         examples=examples,
+        many=many,
+    )
+
+
+# PUBLIC API
+
+
+def convert_pydantic(
+    model_class: Type[BaseModel],
+    *,
+    description: str = "",
+    examples: Sequence[Tuple[str, Dict[str, Any]]] = tuple(),
+) -> Object:
+    """Convert a pydantic model to Kor internal representation.
+
+    Args:
+        model_class: The pydantic model class to convert.
+        description: The description of the model.
+        examples: A sequence of examples of the model.
+    """
+    return _convert_pydantic_internal(
+        model_class, description=description, examples=examples
     )

--- a/kor/adapters.py
+++ b/kor/adapters.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel
+from typing import Type, Sequence, Tuple
+
+from .nodes import Object, Text, Number
+
+
+def convert_pydantic(
+    model_class: Type[BaseModel], examples: Sequence[Tuple[str, str]] = tuple()
+) -> Object:
+    """Convert a pydantic model to a kor Object."""
+    attributes = []
+    for field_name, field in model_class.__fields__.items():
+        type_ = field.type_
+        if issubclass(type_, BaseModel):
+            attr = convert_pydantic(type_)
+        elif isinstance(type_, (int, float)):
+            attr = Number(id=field.name)
+        else:
+            attr = Text(id=field.name)
+
+        attributes.append(attr)
+
+    return Object(
+        id=model_class.__class__.__name__.lower(),
+        attributes=attributes,
+        examples=examples,
+    )

--- a/kor/adapters.py
+++ b/kor/adapters.py
@@ -1,9 +1,10 @@
 """Adapters to convert from validation frameworks to Kor internal representation."""
 import enum
-from pydantic import BaseModel
-from typing import Any, Dict, Optional, Sequence, Tuple, Type, get_origin, List, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union, get_origin
 
-from .nodes import Number, Object, Text, ExtractionSchemaNode, Selection, Option
+from pydantic import BaseModel
+
+from .nodes import ExtractionSchemaNode, Number, Object, Option, Selection, Text
 from .validators import PydanticValidator, Validator
 
 
@@ -113,5 +114,5 @@ def from_pydantic(
         examples=examples,
         many=many,
     )
-    validator = PydanticValidator(model_class, schema)
+    validator = PydanticValidator(model_class, schema.many)
     return schema, validator

--- a/kor/encoders/csv_data.py
+++ b/kor/encoders/csv_data.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from kor.encoders.exceptions import ParseError
+from kor.exceptions import ParseError
 from kor.encoders.typedefs import SchemaBasedEncoder
 from kor.encoders.utils import unwrap_tag, wrap_in_tag
 from kor.nodes import AbstractSchemaNode, Object
@@ -104,13 +104,7 @@ class CSVEncoder(SchemaBasedEncoder):
                 except Exception as e:
                     raise ParseError(e)
 
-            if not isinstance(self.node, Object):
-                if self.node.id in df.columns:
-                    records = df[self.node.id].to_list()
-                else:
-                    records = []
-            else:
-                records = df.to_dict(orient="records")
+            records = df.to_dict(orient="records")
         else:
             records = []
 
@@ -121,6 +115,7 @@ class CSVEncoder(SchemaBasedEncoder):
         """Format instructions."""
         instructions = [
             "Please output the extracted information in CSV format in Excel dialect.",
+            f"Please use a {DELIMITER} as the delimiter."
             # TODO(Eugene): Add this when we start supporting embedded columns.
             # "If a column corresponds to an array or an object,
             # use a JSON encoding to "

--- a/kor/encoders/csv_data.py
+++ b/kor/encoders/csv_data.py
@@ -10,9 +10,9 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from kor.exceptions import ParseError
 from kor.encoders.typedefs import SchemaBasedEncoder
 from kor.encoders.utils import unwrap_tag, wrap_in_tag
+from kor.exceptions import ParseError
 from kor.nodes import AbstractSchemaNode, Object
 
 DELIMITER = "|"

--- a/kor/encoders/exceptions.py
+++ b/kor/encoders/exceptions.py
@@ -1,2 +1,0 @@
-class ParseError(Exception):
-    """Exception for parsing errors."""

--- a/kor/encoders/json_data.py
+++ b/kor/encoders/json_data.py
@@ -10,7 +10,7 @@ about the output despite being told not to do that.
 import json
 from typing import Any
 
-from .exceptions import ParseError
+from kor.exceptions import ParseError
 from .typedefs import Encoder
 from .utils import unwrap_tag, wrap_in_tag
 

--- a/kor/encoders/json_data.py
+++ b/kor/encoders/json_data.py
@@ -11,6 +11,7 @@ import json
 from typing import Any
 
 from kor.exceptions import ParseError
+
 from .typedefs import Encoder
 from .utils import unwrap_tag, wrap_in_tag
 

--- a/kor/encoders/parser.py
+++ b/kor/encoders/parser.py
@@ -7,7 +7,11 @@ from kor.encoders import Encoder
 from kor.encoders.exceptions import ParseError
 from kor.nodes import Object
 from kor.validators import Validator
-from langchain.schema import BaseOutputParser
+
+try:
+    from langchain.output_parsers.base import BaseOutputParser
+except ImportError:
+    from langchain.schema import BaseOutputParser  # type: ignore
 
 
 class KorParser(BaseOutputParser):
@@ -41,7 +45,7 @@ class KorParser(BaseOutputParser):
         raw_data = data[key_id]
 
         if self.validator:
-            validated_data = self.validator.validate_and_format(raw_data)
+            validated_data = self.validator.clean_data(raw_data)
         else:
             validated_data = {}
 

--- a/kor/encoders/parser.py
+++ b/kor/encoders/parser.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from pydantic import Extra
 from typing import Any, Dict, Optional
+
+from pydantic import Extra
 
 from kor.encoders import Encoder
 from kor.exceptions import ParseError
@@ -42,8 +43,10 @@ class KorParser(BaseOutputParser):
         if key_id not in data:
             return {"data": {}, "raw": text, "errors": [], "validated_data": {}}
 
+        obj_data = data[key_id]
+
         if self.validator:
-            validated_data, exceptions = self.validator.clean_data(data)
+            validated_data, exceptions = self.validator.clean_data(obj_data)
         else:
             validated_data, exceptions = {}, []
 

--- a/kor/encoders/parser.py
+++ b/kor/encoders/parser.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
+from pydantic import Extra
 from typing import Any, Dict, Optional
 
-from pydantic import Extra
-
 from kor.encoders import Encoder
-from kor.encoders.exceptions import ParseError
+from kor.exceptions import ParseError
 from kor.nodes import Object
 from kor.validators import Validator
 
@@ -36,24 +35,22 @@ class KorParser(BaseOutputParser):
         try:
             data = self.encoder.decode(text)
         except ParseError as e:
-            return {"data": {}, "raw": text, "errors": [repr(e)], "validated_data": {}}
+            return {"data": {}, "raw": text, "errors": [e], "validated_data": {}}
 
         key_id = self.schema_.id
 
         if key_id not in data:
             return {"data": {}, "raw": text, "errors": [], "validated_data": {}}
 
-        raw_data = data[key_id]
-
         if self.validator:
-            validated_data = self.validator.clean_data(raw_data)
+            validated_data, exceptions = self.validator.clean_data(data)
         else:
-            validated_data = {}
+            validated_data, exceptions = {}, []
 
         return {
-            "data": raw_data,
+            "data": data,
             "raw": text,
-            "errors": [],
+            "errors": exceptions,
             "validated_data": validated_data,
         }
 

--- a/kor/encoders/parser.py
+++ b/kor/encoders/parser.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from pydantic import Extra
 from typing import Any, Dict, Optional
+
+from pydantic import Extra
 
 from kor.encoders import Encoder
 from kor.encoders.exceptions import ParseError

--- a/kor/examples.py
+++ b/kor/examples.py
@@ -75,7 +75,8 @@ class SimpleExampleAggregator(AbstractVisitor[List[Tuple[str, str]]]):
             for example in option.examples:
                 examples.append((example, self._assemble_output(node, option.id)))
 
-        examples.extend(node.examples)
+        for example_input, example_output in node.examples:
+            examples.append((example_input, self._assemble_output(node, example_output)))
 
         for null_example in node.null_examples:
             examples.append((null_example, ""))

--- a/kor/examples.py
+++ b/kor/examples.py
@@ -76,7 +76,9 @@ class SimpleExampleAggregator(AbstractVisitor[List[Tuple[str, str]]]):
                 examples.append((example, self._assemble_output(node, option.id)))
 
         for example_input, example_output in node.examples:
-            examples.append((example_input, self._assemble_output(node, example_output)))
+            examples.append(
+                (example_input, self._assemble_output(node, example_output))
+            )
 
         for null_example in node.null_examples:
             examples.append((null_example, ""))

--- a/kor/examples.py
+++ b/kor/examples.py
@@ -75,6 +75,8 @@ class SimpleExampleAggregator(AbstractVisitor[List[Tuple[str, str]]]):
             for example in option.examples:
                 examples.append((example, self._assemble_output(node, option.id)))
 
+        examples.extend(node.examples)
+
         for null_example in node.null_examples:
             examples.append((null_example, ""))
         return examples

--- a/kor/exceptions.py
+++ b/kor/exceptions.py
@@ -1,0 +1,10 @@
+class KorException(Exception):
+    """Base class for all Kor exceptions."""
+
+
+class ParseError(KorException):
+    """Exception for parsing errors."""
+
+
+class ValidationError(KorException):
+    """Exception for validators."""

--- a/kor/extraction.py
+++ b/kor/extraction.py
@@ -1,13 +1,13 @@
+from typing import Any, Optional, Type, Union
+
 from langchain.chains import LLMChain
 from langchain.schema import BaseLanguageModel
-from typing import Any, Type, Union, Optional
 
 from kor.encoders import Encoder, initialize_encoder
 from kor.nodes import AbstractSchemaNode
 from kor.prompts import create_langchain_prompt
 from kor.type_descriptors import TypeDescriptor, initialize_type_descriptors
 from kor.validators import Validator
-
 
 # PUBLIC API
 

--- a/kor/extraction.py
+++ b/kor/extraction.py
@@ -1,40 +1,46 @@
-from typing import Any, Type, Union
-
-from langchain.chains import LLMChain
-from langchain.schema import BaseLanguageModel
+from typing import Any, Type, Union, Optional
 
 from kor.encoders import Encoder, initialize_encoder
 from kor.nodes import AbstractSchemaNode
 from kor.prompts import create_langchain_prompt
 from kor.type_descriptors import TypeDescriptor, initialize_type_descriptors
+from kor.validators import Validator
+from langchain.chains import LLMChain
+from langchain.schema import BaseLanguageModel
+
 
 # PUBLIC API
 
 
 def create_extraction_chain(
     llm: BaseLanguageModel,
-    node: AbstractSchemaNode,
+    schema: AbstractSchemaNode,
     *,
     encoder_or_encoder_class: Union[Type[Encoder], Encoder, str] = "csv",
     type_descriptor: Union[TypeDescriptor, str] = "typescript",
+    validator: Optional[Validator] = None,
     **encoder_kwargs: Any,
 ) -> LLMChain:
     """Create an extraction chain.
 
     Args:
         llm: The language model used for extraction
-        node: the schematic description of what to extract from text
+        schema: the schematic description of what to extract from text
         encoder_or_encoder_class: Either an encoder instance, an encoder class
                                   or a string representing the encoder class
         type_descriptor: The type descriptor to use. This can be either a TypeDescriptor
                           or a string representing the type descriptor name
         encoder_kwargs: Keyword arguments to pass to the encoder class
+        validator: optional validator to use for validation
 
     Returns:
         A langchain chain
     """
-    encoder = initialize_encoder(encoder_or_encoder_class, node, **encoder_kwargs)
+    encoder = initialize_encoder(encoder_or_encoder_class, schema, **encoder_kwargs)
     type_descriptor_to_use = initialize_type_descriptors(type_descriptor)
     return LLMChain(
-        llm=llm, prompt=create_langchain_prompt(node, encoder, type_descriptor_to_use)
+        llm=llm,
+        prompt=create_langchain_prompt(
+            schema, encoder, type_descriptor_to_use, validator
+        ),
     )

--- a/kor/extraction.py
+++ b/kor/extraction.py
@@ -1,3 +1,5 @@
+from langchain.chains import LLMChain
+from langchain.schema import BaseLanguageModel
 from typing import Any, Type, Union, Optional
 
 from kor.encoders import Encoder, initialize_encoder
@@ -5,8 +7,6 @@ from kor.nodes import AbstractSchemaNode
 from kor.prompts import create_langchain_prompt
 from kor.type_descriptors import TypeDescriptor, initialize_type_descriptors
 from kor.validators import Validator
-from langchain.chains import LLMChain
-from langchain.schema import BaseLanguageModel
 
 
 # PUBLIC API

--- a/kor/extraction.py
+++ b/kor/extraction.py
@@ -14,7 +14,7 @@ from langchain.schema import BaseLanguageModel
 
 def create_extraction_chain(
     llm: BaseLanguageModel,
-    schema: AbstractSchemaNode,
+    node: AbstractSchemaNode,
     *,
     encoder_or_encoder_class: Union[Type[Encoder], Encoder, str] = "csv",
     type_descriptor: Union[TypeDescriptor, str] = "typescript",
@@ -25,7 +25,7 @@ def create_extraction_chain(
 
     Args:
         llm: The language model used for extraction
-        schema: the schematic description of what to extract from text
+        node: the schematic description of what to extract from text
         encoder_or_encoder_class: Either an encoder instance, an encoder class
                                   or a string representing the encoder class
         type_descriptor: The type descriptor to use. This can be either a TypeDescriptor
@@ -36,11 +36,11 @@ def create_extraction_chain(
     Returns:
         A langchain chain
     """
-    encoder = initialize_encoder(encoder_or_encoder_class, schema, **encoder_kwargs)
+    encoder = initialize_encoder(encoder_or_encoder_class, node, **encoder_kwargs)
     type_descriptor_to_use = initialize_type_descriptors(type_descriptor)
     return LLMChain(
         llm=llm,
         prompt=create_langchain_prompt(
-            schema, encoder, type_descriptor_to_use, validator
+            node, encoder, type_descriptor_to_use, validator
         ),
     )

--- a/kor/nodes.py
+++ b/kor/nodes.py
@@ -217,7 +217,7 @@ class Selection(AbstractSchemaNode):
         from the text: "I eat an apple every day.".
     """
 
-    __slots__ = "options", "null_examples"
+    __slots__ = "options", "examples", "null_examples"
 
     def __init__(
         self,
@@ -226,6 +226,7 @@ class Selection(AbstractSchemaNode):
         description: str = "",
         many: bool = False,
         options: Sequence[Option],
+        examples: Sequence[Tuple[str, Union[str, Sequence[str]]]] = tuple(),
         null_examples: Sequence[str] = tuple(),
     ) -> None:
         """Initialize for extraction input."""
@@ -234,6 +235,7 @@ class Selection(AbstractSchemaNode):
         if not options:
             raise ValueError("Selection inputs must have at least one option.")
         self.options = options
+        self.examples = examples
         self.null_examples = null_examples
 
     def accept(self, visitor: AbstractVisitor[T]) -> T:

--- a/kor/nodes.py
+++ b/kor/nodes.py
@@ -1,20 +1,19 @@
 """Definitions of input elements."""
-import operator
-
 import abc
 import copy
-import re
 import inspect
+import operator
+import re
 from typing import (
     Any,
     Generic,
+    List,
     Mapping,
     Optional,
     Sequence,
     Tuple,
     TypeVar,
     Union,
-    List,
 )
 
 # For now, limit what's allowed for identifiers.

--- a/kor/nodes.py
+++ b/kor/nodes.py
@@ -119,9 +119,7 @@ class AbstractSchemaNode(abc.ABC):
         if not isinstance(self, AbstractSchemaNode):
             raise AssertionError(f"Cannot compare {type(self)} with {type(other)}")
         if type(self) != type(other):
-            raise NotImplementedError(
-                f'Cannot compare "{type(self)}" {self.id} with "{type(other)}"'
-            )
+            return False
 
         if _get_all_slots(self) == _get_all_slots(other):
             attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]

--- a/kor/nodes.py
+++ b/kor/nodes.py
@@ -28,12 +28,12 @@ VALID_IDENTIFIER_PATTERN = re.compile(r"^[a-z_][0-9a-z_]*$")
 T = TypeVar("T")
 
 
-def _get_all_slots(cls) -> List[str]:
+def _get_all_slots(node: "AbstractSchemaNode") -> List[str]:
     """Get a list of all slots."""
-    slots = []
-    for cls in inspect.getmro(type(cls)):
-        if hasattr(cls, "__slots__"):
-            slots += cls.__slots__
+    slots: List[str] = []
+    for class_ in inspect.getmro(type(node)):
+        if hasattr(class_, "__slots__"):
+            slots.extend(class_.__slots__)
     return sorted(slots)
 
 

--- a/kor/prompts.py
+++ b/kor/prompts.py
@@ -1,6 +1,14 @@
 """Code to dynamically generate appropriate LLM prompts."""
 from __future__ import annotations
 
+from langchain import BasePromptTemplate
+from langchain.schema import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    PromptValue,
+    SystemMessage,
+)
 from pydantic import Extra
 from typing import Any, List, Tuple, Optional
 
@@ -10,14 +18,6 @@ from kor.encoders.parser import KorParser
 from kor.examples import generate_examples
 from kor.nodes import AbstractSchemaNode
 from kor.type_descriptors import TypeDescriptor
-from langchain import BasePromptTemplate
-from langchain.schema import (
-    AIMessage,
-    BaseMessage,
-    HumanMessage,
-    PromptValue,
-    SystemMessage,
-)
 from .validators import Validator
 
 

--- a/kor/prompts.py
+++ b/kor/prompts.py
@@ -1,8 +1,15 @@
 """Code to dynamically generate appropriate LLM prompts."""
 from __future__ import annotations
 
-from typing import Any, List, Literal, Tuple, Union
+from pydantic import Extra
+from typing import Any, List, Tuple, Optional
 
+from kor.encoders import Encoder
+from kor.encoders.encode import encode_examples
+from kor.encoders.parser import KorParser
+from kor.examples import generate_examples
+from kor.nodes import AbstractSchemaNode
+from kor.type_descriptors import TypeDescriptor
 from langchain import BasePromptTemplate
 from langchain.schema import (
     AIMessage,
@@ -11,16 +18,7 @@ from langchain.schema import (
     PromptValue,
     SystemMessage,
 )
-from pydantic import Extra
-
-from kor.encoders import Encoder
-from kor.encoders.encode import encode_examples
-from kor.encoders.parser import KorParser
-from kor.examples import generate_examples
-from kor.nodes import AbstractSchemaNode
-from kor.type_descriptors import TypeDescriptor
-
-PromptFormat = Union[Literal["openai-chat"], Literal["string"]]
+from .validators import Validator
 
 
 class ExtractionPromptValue(PromptValue):
@@ -131,12 +129,15 @@ class ExtractionPromptTemplate(BasePromptTemplate):
 
 
 def create_langchain_prompt(
-    schema: AbstractSchemaNode, encoder: Encoder, type_descriptor: TypeDescriptor
+    schema: AbstractSchemaNode,
+    encoder: Encoder,
+    type_descriptor: TypeDescriptor,
+    validator: Optional[Validator] = None,
 ) -> ExtractionPromptTemplate:
     """Create a langchain style prompt with specified encoder."""
     return ExtractionPromptTemplate(
         input_variables=["text"],
-        output_parser=KorParser(encoder=encoder),
+        output_parser=KorParser(encoder=encoder, validator=validator, schema_=schema),
         encoder=encoder,
         node=schema,
         type_descriptor=type_descriptor,

--- a/kor/prompts.py
+++ b/kor/prompts.py
@@ -1,6 +1,8 @@
 """Code to dynamically generate appropriate LLM prompts."""
 from __future__ import annotations
 
+from typing import Any, List, Optional, Tuple
+
 from langchain import BasePromptTemplate
 from langchain.schema import (
     AIMessage,
@@ -10,7 +12,6 @@ from langchain.schema import (
     SystemMessage,
 )
 from pydantic import Extra
-from typing import Any, List, Tuple, Optional
 
 from kor.encoders import Encoder
 from kor.encoders.encode import encode_examples
@@ -18,6 +19,7 @@ from kor.encoders.parser import KorParser
 from kor.examples import generate_examples
 from kor.nodes import AbstractSchemaNode
 from kor.type_descriptors import TypeDescriptor
+
 from .validators import Validator
 
 

--- a/kor/test_validators.py
+++ b/kor/test_validators.py
@@ -1,7 +1,5 @@
 """Test validator module."""
-import pytest
-from pydantic import BaseModel, ValidationError
-from pydantic import validator as pydantic_validator
+from pydantic import BaseModel, ValidationError, validator as pydantic_validator
 
 from kor.validators import (
     PydanticValidator,
@@ -26,9 +24,12 @@ def test_pydantic_validator() -> None:
 
     # Adding an unused
     validator = PydanticValidator(ToyModel, None)  # type: ignore
-    assert validator.clean_data({"name": "Eugene", "age": 5}) == ToyModel(
-        name="Eugene", age=5
+    assert validator.clean_data({"name": "Eugene", "age": 5}) == (
+        ToyModel(name="Eugene", age=5),
+        [],
     )
 
-    with pytest.raises(ValidationError):
-        validator.clean_data({"name": "Eugene", "age": -1})
+    clean_data, exceptions = validator.clean_data({"name": "Eugene", "age": -1})
+    assert clean_data == None
+    assert len(exceptions) == 1
+    assert isinstance(exceptions[0], ValidationError)

--- a/kor/test_validators.py
+++ b/kor/test_validators.py
@@ -12,6 +12,8 @@ def test_pydantic_validator() -> None:
     """Test the PydanticValidator wrapper around pydantic."""
 
     class ToyModel(BaseModel):
+        """Toy model for testing purposes."""
+
         name: str
         age: int
 
@@ -22,7 +24,8 @@ def test_pydantic_validator() -> None:
                 raise ValueError("age must be positive")
             return v
 
-    validator = PydanticValidator(ToyModel)
+    # Adding an unused
+    validator = PydanticValidator(ToyModel, None)  # type: ignore
     assert validator.clean_data({"name": "Eugene", "age": 5}) == ToyModel(
         name="Eugene", age=5
     )

--- a/kor/test_validators.py
+++ b/kor/test_validators.py
@@ -1,6 +1,7 @@
 """Test validator module."""
 import pytest
-from pydantic import BaseModel, validator as pydantic_validator, ValidationError
+from pydantic import BaseModel, ValidationError
+from pydantic import validator as pydantic_validator
 
 from kor.validators import (
     PydanticValidator,

--- a/kor/test_validators.py
+++ b/kor/test_validators.py
@@ -1,0 +1,30 @@
+"""Test validator module."""
+import pytest
+from pydantic import BaseModel, validator as pydantic_validator, ValidationError
+
+from kor.validators import (
+    PydanticValidator,
+)
+
+
+def test_pydantic_validator():
+    """Test the PydanticValidator wrapper around pydantic."""
+
+    class ToyModel(BaseModel):
+        name: str
+        age: int
+
+        @pydantic_validator("age")
+        def age_must_be_positive(cls, v: int) -> int:
+            """Add an age constraint"""
+            if v < 0:
+                raise ValueError("age must be positive")
+            return v
+
+    validator = PydanticValidator(ToyModel)
+    assert validator.clean_data({"name": "Eugene", "age": 5}) == ToyModel(
+        name="Eugene", age=5
+    )
+
+    with pytest.raises(ValidationError):
+        validator.clean_data({"name": "Eugene", "age": -1})

--- a/kor/test_validators.py
+++ b/kor/test_validators.py
@@ -8,7 +8,7 @@ from kor.validators import (
 )
 
 
-def test_pydantic_validator():
+def test_pydantic_validator() -> None:
     """Test the PydanticValidator wrapper around pydantic."""
 
     class ToyModel(BaseModel):

--- a/kor/test_validators.py
+++ b/kor/test_validators.py
@@ -1,5 +1,6 @@
 """Test validator module."""
-from pydantic import BaseModel, ValidationError, validator as pydantic_validator
+from pydantic import BaseModel, ValidationError
+from pydantic import validator as pydantic_validator
 
 from kor.validators import (
     PydanticValidator,
@@ -30,6 +31,6 @@ def test_pydantic_validator() -> None:
     )
 
     clean_data, exceptions = validator.clean_data({"name": "Eugene", "age": -1})
-    assert clean_data == None
+    assert clean_data is None
     assert len(exceptions) == 1
     assert isinstance(exceptions[0], ValidationError)

--- a/kor/validators.py
+++ b/kor/validators.py
@@ -1,4 +1,38 @@
-"""Define validator interface and provide built-in validators for common-use cases.
+"""Define validator interface and provide built-in validators for common-use cases."""
+import abc
+from typing import Any, Type, Union, List, Mapping
+from pydantic import BaseModel
 
-This is a placeholder file.
-"""
+
+class Validator(abc.ABC):
+    def is_valid(self, result) -> bool:
+        """Check if the result is valid."""
+        raise NotImplementedError()
+
+    def validate_and_format(self, result) -> Any:
+        """Validate and format the result."""
+        raise NotImplementedError()
+
+
+class PydanticValidator(Validator):
+    def __init__(self, model_class: Type[BaseModel], many: bool) -> None:
+        """Create a validator for a pydantic model."""
+        self.model_class = model_class
+        self.many = many
+
+    def is_valid(self, result) -> bool:
+        """Check if the result is valid."""
+        try:
+            self.model_class.validate(result)
+            return True
+        except Exception:
+            return False
+
+    def validate_and_format(
+        self, data: Union[List[Mapping[str, Any]], Mapping[str, Any]]
+    ) -> Any:
+        """Validate and format the result."""
+        if self.many:
+            return [self.model_class(**item) for item in data]
+        else:
+            return self.model_class(**data)

--- a/kor/validators.py
+++ b/kor/validators.py
@@ -38,7 +38,7 @@ class PydanticValidator(Validator):
 
     def clean_data(
         self, data: Any
-    ) -> Tuple[Optional[BaseModel] | List[BaseModel], List[Exception]]:
+    ) -> Tuple[Union[Optional[BaseModel], List[BaseModel]], List[Exception]]:
         """Clean the data using the pydantic model.
 
         Args:

--- a/kor/validators.py
+++ b/kor/validators.py
@@ -1,7 +1,9 @@
 """Define validator interface and provide built-in validators for common-use cases."""
 import abc
-from pydantic import BaseModel, ValidationError as PydanticValidationError
 from typing import Any, List, Mapping, Optional, Tuple, Type, Union
+
+from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
 
 
 class Validator(abc.ABC):

--- a/kor/validators.py
+++ b/kor/validators.py
@@ -1,7 +1,8 @@
 """Define validator interface and provide built-in validators for common-use cases."""
 import abc
+from typing import Any, List, Mapping, Type, Union
+
 from pydantic import BaseModel
-from typing import Any, Type, Union, List, Mapping
 
 
 class Validator(abc.ABC):

--- a/kor/validators.py
+++ b/kor/validators.py
@@ -32,7 +32,7 @@ class PydanticValidator(Validator):
         """
         self.model_class = model_class
 
-    def clean_data(self, data: Mapping[str, Any]) -> Union[List[BaseModel], BaseModel]:
+    def clean_data(self, data: Any) -> Union[List[BaseModel], BaseModel]:
         """Clean the data using the pydantic model.
 
         Args:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import operator
-from typing import List, Optional, Any
+from typing import Any, List, Optional
 
 from kor.nodes import AbstractSchemaNode, _get_all_slots
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,8 @@ def pytest_assertrepr_compare(op: str, left: Any, right: Any) -> Optional[List[s
         if type(left) != type(right):
             return [
                 "Comparing AbstractSchemaNode instances:",
-                f"Type mismatch: {type(left)} != {type(right)}",
+                f"Type mismatch: {type(left)} ({left.id}) != "
+                f"{type(right)} ({right.id})",
             ]
 
         all_slots = _get_all_slots(left)
@@ -33,7 +34,7 @@ def pytest_assertrepr_compare(op: str, left: Any, right: Any) -> Optional[List[s
             if not isinstance(left, Object) and not isinstance(right, Object):
                 raise AssertionError("Expected both nodes to be of type Object")
             left = cast(Object, left)
-            right = cast(Object, left)
+            right = cast(Object, right)
             if len(left.attributes) != len(right.attributes):
                 return [
                     "Comparing AbstractSchemaNode instances:",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
-from typing import List, Optional, Any
-
 import operator
+from typing import List, Optional, Any
 
 from kor.nodes import AbstractSchemaNode, _get_all_slots
 
@@ -17,10 +16,27 @@ def pytest_assertrepr_compare(op: str, left: Any, right: Any) -> Optional[List[s
         and op == "=="
     ):
         all_slots = _get_all_slots(left)
-        attr_getters = [(attr, operator.attrgetter(attr)) for attr in all_slots]
+
+        attr_getters = [
+            (attr, operator.attrgetter(attr))
+            for attr in all_slots
+            if attr != "attributes"
+        ]
+
+        if "attributes" in all_slots:
+            if len(left.attributes) != len(right.attributes):
+                return [
+                    "Comparing AbstractSchemaNode instances:",
+                    f"attributes: {left.attributes} != {right.attributes}",
+                ]
+            for attr1, attr2 in zip(left.attributes, right.attributes):
+                if attr1 != attr2:
+                    return pytest_assertrepr_compare(op, attr1, attr2)
 
         return [
             "Comparing AbstractSchemaNode instances:",
-            ", ".join([f"{attr}: {getter(left)}" for attr, getter in attr_getters]),
-            ", ".join([f"{attr}: {getter(right)}" for attr, getter in attr_getters]),
+            f"{left}: "
+            + ", ".join([f"{attr}: {getter(left)}" for attr, getter in attr_getters]),
+            f"{right}: "
+            + ", ".join([f"{attr}: {getter(right)}" for attr, getter in attr_getters]),
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+from typing import List, Optional, Any
+
+import operator
+
+from kor.nodes import AbstractSchemaNode, _get_all_slots
+
+
+def pytest_assertrepr_compare(op: str, left: Any, right: Any) -> Optional[List[str]]:
+    """Temporary implementation of custom fail messages for schema nodes.
+
+    This code will go away once it is decided what to use for modeling schema nodes
+    instead of vanilla python classes.
+    """
+    if (
+        isinstance(left, AbstractSchemaNode)
+        and isinstance(right, AbstractSchemaNode)
+        and op == "=="
+    ):
+        all_slots = _get_all_slots(left)
+        attr_getters = [(attr, operator.attrgetter(attr)) for attr in all_slots]
+
+        return [
+            "Comparing AbstractSchemaNode instances:",
+            ", ".join([f"{attr}: {getter(left)}" for attr, getter in attr_getters]),
+            ", ".join([f"{attr}: {getter(right)}" for attr, getter in attr_getters]),
+        ]

--- a/tests/test_adpaters.py
+++ b/tests/test_adpaters.py
@@ -1,0 +1,19 @@
+from kor.adapters import translate_pydantic_to_kor
+from kor.nodes import Number, Object, Text
+
+import pydantic
+
+
+def test_convert_pydantic() -> None:
+    """Convert a pydantic object to a dictionary."""
+
+    class Toy(pydantic.BaseModel):
+        """Toy pydantic object."""
+
+        a: str
+        b: int
+
+    assert translate_pydantic_to_kor(Toy) == Object(
+        id="toy",
+        attributes=[Text(id="a"), Number(id="b")],
+    )

--- a/tests/test_adpaters.py
+++ b/tests/test_adpaters.py
@@ -33,7 +33,8 @@ def test_convert_pydantic() -> None:
             Number(id="b", examples=[("b is 1", "1")]),
             Number(id="c"),
             Text(id="d"),  # We do not support boolean types yet.
-            # We don't have optional yet internally, so we don't check the optional setting.
+            # We don't have optional yet internally, so we don't check the
+            # optional setting.
             Number(id="e"),  # We don't have a boolean type yet.
             Number(id="f", many=True),
             Text(id="g", many=True),

--- a/tests/test_adpaters.py
+++ b/tests/test_adpaters.py
@@ -2,7 +2,7 @@ import pydantic
 from pydantic.fields import Field
 
 from kor.adapters import _translate_pydantic_to_kor, from_pydantic
-from kor.nodes import Number, Object, Text, Optional, List
+from kor.nodes import List, Number, Object, Optional, Text
 
 
 def test_convert_pydantic() -> None:

--- a/tests/test_adpaters.py
+++ b/tests/test_adpaters.py
@@ -58,7 +58,7 @@ def test_from_pydantic() -> None:
         b: int
 
     node, validator = from_pydantic(Toy)
-    assert validator.clean_data({"a": "hello", "b": 5}) == Toy(a="hello", b=5)
+    assert validator.clean_data({"a": "hello", "b": 5}) == (Toy(a="hello", b=5), [])
     assert node == Object(
         id="toy",
         attributes=[Text(id="a"), Number(id="b")],

--- a/tests/test_adpaters.py
+++ b/tests/test_adpaters.py
@@ -1,7 +1,7 @@
-from kor.adapters import translate_pydantic_to_kor
-from kor.nodes import Number, Object, Text
-
 import pydantic
+
+from kor.adapters import _translate_pydantic_to_kor, from_pydantic
+from kor.nodes import Number, Object, Text, Optional, List
 
 
 def test_convert_pydantic() -> None:
@@ -12,8 +12,33 @@ def test_convert_pydantic() -> None:
 
         a: str
         b: int
+        c: Optional[int] = None
+        d: List[int] = []
 
-    assert translate_pydantic_to_kor(Toy) == Object(
+    node = _translate_pydantic_to_kor(Toy)
+    assert node == Object(
+        id="toy",
+        attributes=[
+            Text(id="a"),
+            Number(id="b"),
+            Number(id="c"),
+            Number(id="d", many=True),
+        ],
+    )
+
+
+def test_from_pydantic() -> None:
+    """Test from pydantic function."""
+
+    class Toy(pydantic.BaseModel):
+        """Toy pydantic object."""
+
+        a: str
+        b: int
+
+    node, validator = from_pydantic(Toy)
+    assert validator.clean_data({"a": "hello", "b": 5}) == Toy(a="hello", b=5)
+    assert node == Object(
         id="toy",
         attributes=[Text(id="a"), Number(id="b")],
     )

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -63,7 +63,7 @@ def test_create_extraction_chain(options: Mapping[str, Any]) -> None:
     """Create an extraction chain."""
     chat_model = ToyChatModel(response="hello")
 
-    for schema in [SIMPLE_TEXT_SCHEMA, SIMPLE_OBJECT_SCHEMA]:
+    for schema in [SIMPLE_OBJECT_SCHEMA]:
         chain = create_extraction_chain(chat_model, schema, **options)
         assert isinstance(chain, LLMChain)
         # Try to run through predict and parse
@@ -73,12 +73,7 @@ def test_create_extraction_chain(options: Mapping[str, Any]) -> None:
 @pytest.mark.parametrize(
     "options",
     [
-        {"encoder_or_encoder_class": CSVEncoder, "node": SIMPLE_TEXT_SCHEMA},
         {"encoder_or_encoder_class": CSVEncoder, "node": SIMPLE_OBJECT_SCHEMA},
-        {
-            "encoder_or_encoder_class": CSVEncoder(SIMPLE_TEXT_SCHEMA),
-            "node": SIMPLE_TEXT_SCHEMA,
-        },
         {
             "encoder_or_encoder_class": CSVEncoder(SIMPLE_OBJECT_SCHEMA),
             "node": SIMPLE_OBJECT_SCHEMA,

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -20,4 +20,5 @@ def test_kor__all__() -> None:
         "TypeScriptDescriptor",
         "XMLEncoder",
         "create_extraction_chain",
+        "from_pydantic",
     ]


### PR DESCRIPTION
* Added adapter that can import pydantic models and use them for validation. Support for pydantic is to be considered partial.
* Added information about delimiter to csv encoder (useful when no examples are provided)
* Chain output includes an additional key called `validated_data` that contains data that was validated by pydantic
* Added a way to specify examples at the Selection node (to provide a way to specify examples when using an enum type with pydantic)
* Forcing kor schema node to be an Object at the top level


![image](https://user-images.githubusercontent.com/3205522/227722325-5faa387e-b735-46ef-a064-d5e267e3565c.png)