### PR TITLE
Deprecate group_as_object attribute

### DIFF
--- a/kor/examples.py
+++ b/kor/examples.py
@@ -41,29 +41,25 @@ class SimpleExampleAggregator(AbstractVisitor[List[Tuple[str, str]]]):
         """Implementation of an object visitor."""
         examples = []
         if node.examples:
-            if node.group_as_object:
-                object_examples = [
-                    # Looks like false positive from mypy
-                    # Can investigate how to simplify at a later point.
-                    (
-                        example_input,
-                        self._assemble_output(node, example_output),
-                    )
-                    for example_input, example_output in node.examples
-                ]
-                examples.extend(object_examples)
-            else:
-                raise NotImplementedError("Not implemented yet")
+            object_examples = [
+                # Looks like false positive from mypy
+                # Can investigate how to simplify at a later point.
+                (
+                    example_input,
+                    self._assemble_output(node, example_output),
+                )
+                for example_input, example_output in node.examples
+            ]
+            examples.extend(object_examples)
 
         # Collect examples from children
         for child in node.attributes:
             child_examples = child.accept(self)
-            if node.group_as_object:  # Take care of namespaces
-                child_examples = [
-                    (example_input, self._assemble_output(node, example_output))
-                    for example_input, example_output in child_examples
-                ]
-
+            # Take care of namespaces
+            child_examples = [
+                (example_input, self._assemble_output(node, example_output))
+                for example_input, example_output in child_examples
+            ]
             examples.extend(child_examples)
 
         return examples

--- a/kor/nodes.py
+++ b/kor/nodes.py
@@ -270,7 +270,7 @@ class Object(AbstractSchemaNode):
         from the text: "I eat an apple every day.".
     """
 
-    __slots__ = ("attributes", "examples", "group_as_object")
+    __slots__ = ("attributes", "examples")
 
     def __init__(
         self,
@@ -284,16 +284,11 @@ class Object(AbstractSchemaNode):
         examples: Sequence[
             Tuple[str, Mapping[str, Union[str, Sequence[str]]]]
         ] = tuple(),
-        # If false, will treat the inputs independent.
-        # Is there a better name for this?! I want it to be True by default
-        # which rules out as_input_bag
-        group_as_object: bool = True,
     ) -> None:
         """Initialize for extraction input."""
         super().__init__(id=id, description=description, many=many)
         self.attributes = attributes
         self.examples = examples
-        self.group_as_object = group_as_object
 
     def accept(self, visitor: AbstractVisitor[T]) -> T:
         """Accept a visitor."""


### PR DESCRIPTION
Deprecate this attribute for now. It's unclear whether it's needed.
