### PR TITLE
Add pydantic adapter test for model with Enum

### DIFF
--- a/tests/test_adpaters.py
+++ b/tests/test_adpaters.py
@@ -4,7 +4,7 @@ import pydantic
 from pydantic.fields import Field
 
 from kor.adapters import _translate_pydantic_to_kor, from_pydantic
-from kor.nodes import List, Number, Object, Optional, Text, Selection, Option
+from kor.nodes import List, Number, Object, Option, Optional, Selection, Text
 
 
 def test_convert_pydantic() -> None:


### PR DESCRIPTION
Add a test that a pydantic model that uses an enum attribute gets translated to
a correct internal representation.
