### PR TITLE
Remove *args from visitors

### DIFF
--- a/kor/examples.py
+++ b/kor/examples.py
@@ -24,9 +24,7 @@ T = TypeVar("T")
 class SimpleExampleAggregator(AbstractVisitor[List[Tuple[str, str]]]):
     """Use to visit node and all of its descendents and aggregates all examples."""
 
-    def visit_option(
-        self, node: "Option", *args: Any, **kwargs: Any
-    ) -> List[Tuple[str, str]]:
+    def visit_option(self, node: "Option", **kwargs: Any) -> List[Tuple[str, str]]:
         """Should not visit Options directly."""
         raise AssertionError("Should never visit an Option node.")
 
@@ -39,9 +37,7 @@ class SimpleExampleAggregator(AbstractVisitor[List[Tuple[str, str]]]):
             data = [data]
         return {node.id: data}
 
-    def visit_object(
-        self, node: "Object", *args: Any, **kwargs: Any
-    ) -> List[Tuple[str, str]]:
+    def visit_object(self, node: "Object", **kwargs: Any) -> List[Tuple[str, str]]:
         """Implementation of an object visitor."""
         examples = []
         if node.examples:
@@ -69,7 +65,7 @@ class SimpleExampleAggregator(AbstractVisitor[List[Tuple[str, str]]]):
         return examples
 
     def visit_selection(
-        self, node: "Selection", *args: Any, **kwargs: Any
+        self, node: "Selection", **kwargs: Any
     ) -> List[Tuple[str, str]]:
         """Selection visitor."""
         examples = []
@@ -87,7 +83,7 @@ class SimpleExampleAggregator(AbstractVisitor[List[Tuple[str, str]]]):
         return examples
 
     def visit_default(
-        self, node: "AbstractSchemaNode", *args: Any, **kwargs: Any
+        self, node: "AbstractSchemaNode", **kwargs: Any
     ) -> List[Tuple[str, str]]:
         """Default visitor implementation."""
         if not isinstance(node, ExtractionSchemaNode):

--- a/kor/nodes.py
+++ b/kor/nodes.py
@@ -41,27 +41,27 @@ def _get_all_slots(node: "AbstractSchemaNode") -> List[str]:
 class AbstractVisitor(Generic[T], abc.ABC):
     """An abstract visitor."""
 
-    def visit_text(self, node: "Text", *args: Any, **kwargs: Any) -> T:
+    def visit_text(self, node: "Text", **kwargs: Any) -> T:
         """Visit text node."""
-        return self.visit_default(node, *args, **kwargs)
+        return self.visit_default(node, **kwargs)
 
-    def visit_number(self, node: "Number", *args: Any, **kwargs: Any) -> T:
+    def visit_number(self, node: "Number", **kwargs: Any) -> T:
         """Visit text node."""
-        return self.visit_default(node, *args, **kwargs)
+        return self.visit_default(node, **kwargs)
 
-    def visit_object(self, node: "Object", *args: Any, **kwargs: Any) -> T:
+    def visit_object(self, node: "Object", **kwargs: Any) -> T:
         """Visit object node."""
-        return self.visit_default(node, *args, **kwargs)
+        return self.visit_default(node, **kwargs)
 
-    def visit_selection(self, node: "Selection", *args: Any, **kwargs: Any) -> T:
+    def visit_selection(self, node: "Selection", **kwargs: Any) -> T:
         """Visit selection node."""
-        return self.visit_default(node, *args, **kwargs)
+        return self.visit_default(node, **kwargs)
 
-    def visit_option(self, node: "Option", *args: Any, **kwargs: Any) -> T:
+    def visit_option(self, node: "Option", **kwargs: Any) -> T:
         """Visit option node."""
-        return self.visit_default(node, *args, **kwargs)
+        return self.visit_default(node, **kwargs)
 
-    def visit_default(self, node: "AbstractSchemaNode", *args: Any, **kwargs: Any) -> T:
+    def visit_default(self, node: "AbstractSchemaNode", **kwargs: Any) -> T:
         """Default node implementation."""
         raise NotImplementedError()
 
@@ -93,7 +93,7 @@ class AbstractSchemaNode(abc.ABC):
             )
 
     @abc.abstractmethod
-    def accept(self, visitor: AbstractVisitor[T], *args: Any, **kwargs: Any) -> T:
+    def accept(self, visitor: AbstractVisitor[T], **kwargs: Any) -> T:
         """Accept a visitor."""
         raise NotImplementedError()
 
@@ -164,17 +164,17 @@ class ExtractionSchemaNode(AbstractSchemaNode, abc.ABC):
 class Number(ExtractionSchemaNode):
     """Built-in number input."""
 
-    def accept(self, visitor: AbstractVisitor[T], *args: Any, **kwargs: Any) -> T:
+    def accept(self, visitor: AbstractVisitor[T], **kwargs: Any) -> T:
         """Accept a visitor."""
-        return visitor.visit_number(self, *args, **kwargs)
+        return visitor.visit_number(self, **kwargs)
 
 
 class Text(ExtractionSchemaNode):
     """Built-in text input."""
 
-    def accept(self, visitor: AbstractVisitor[T], *args: Any, **kwargs: Any) -> T:
+    def accept(self, visitor: AbstractVisitor[T], **kwargs: Any) -> T:
         """Accept a visitor."""
-        return visitor.visit_text(self, *args, **kwargs)
+        return visitor.visit_text(self, **kwargs)
 
 
 class Option(AbstractSchemaNode):
@@ -198,9 +198,9 @@ class Option(AbstractSchemaNode):
         super().__init__(id=id, description=description, many=many)
         self.examples = examples
 
-    def accept(self, visitor: AbstractVisitor[T], *args: Any, **kwargs: Any) -> T:
+    def accept(self, visitor: AbstractVisitor[T], **kwargs: Any) -> T:
         """Accept a visitor."""
-        return visitor.visit_option(self, *args, **kwargs)
+        return visitor.visit_option(self, **kwargs)
 
 
 class Selection(AbstractSchemaNode):
@@ -257,9 +257,9 @@ class Selection(AbstractSchemaNode):
         self.examples = examples
         self.null_examples = null_examples
 
-    def accept(self, visitor: AbstractVisitor[T], *args: Any, **kwargs: Any) -> T:
+    def accept(self, visitor: AbstractVisitor[T], **kwargs: Any) -> T:
         """Accept a visitor."""
-        return visitor.visit_selection(self, *args, **kwargs)
+        return visitor.visit_selection(self, **kwargs)
 
 
 class Object(AbstractSchemaNode):
@@ -309,6 +309,6 @@ class Object(AbstractSchemaNode):
         self.attributes = attributes
         self.examples = examples
 
-    def accept(self, visitor: AbstractVisitor[T], *args: Any, **kwargs: Any) -> T:
+    def accept(self, visitor: AbstractVisitor[T], **kwargs: Any) -> T:
         """Accept a visitor."""
-        return visitor.visit_object(self, *args, **kwargs)
+        return visitor.visit_object(self, **kwargs)

--- a/kor/type_descriptors.py
+++ b/kor/type_descriptors.py
@@ -47,16 +47,14 @@ class BulletPointDescriptor(TypeDescriptor[None]):
         self.depth = 0
         self.code_lines: List[str] = []
 
-    def visit_default(
-        self, node: "AbstractSchemaNode", *args: Any, **kwargs: Any
-    ) -> None:
+    def visit_default(self, node: "AbstractSchemaNode", **kwargs: Any) -> None:
         """Default action for a node."""
         space = "* " + self.depth * " "
         self.code_lines.append(
             f"{space}{node.id}: {node.__class__.__name__} # {node.description}"
         )
 
-    def visit_object(self, node: Object, *args: Any, **kwargs: Any) -> None:
+    def visit_object(self, node: Object, **kwargs: Any) -> None:
         """Visit an object node."""
         self.visit_default(node)
         self.depth += 1
@@ -82,9 +80,7 @@ class TypeScriptDescriptor(TypeDescriptor[None]):
         self.depth = 0
         self.code_lines: List[str] = []
 
-    def visit_default(
-        self, node: "AbstractSchemaNode", *args: Any, **kwargs: Any
-    ) -> None:
+    def visit_default(self, node: "AbstractSchemaNode", **kwargs: Any) -> None:
         """Default action for a node."""
         space = self.depth * " "
 
@@ -104,7 +100,7 @@ class TypeScriptDescriptor(TypeDescriptor[None]):
             f"{space}{node.id}: {finalized_type} // {node.description}"
         )
 
-    def visit_object(self, node: Object, *args: Any, **kwargs: Any) -> None:
+    def visit_object(self, node: Object, **kwargs: Any) -> None:
         """Visit an object node."""
         space = self.depth * " "
 

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -16,13 +16,13 @@ from kor.nodes import (
 class TestVisitor(AbstractVisitor[Any]):
     """Toy input for tests."""
 
-    def visit_default(self, node: AbstractSchemaNode, *args: Any, **kwargs: Any) -> Any:
+    def visit_default(self, node: AbstractSchemaNode, **kwargs: Any) -> Any:
         """Verify default is invoked"""
-        return node.id, args, kwargs
+        return node.id, kwargs
 
-    def visit(self, node: AbstractSchemaNode, *args: Any, **kwargs: Any) -> Any:
+    def visit(self, node: AbstractSchemaNode, **kwargs: Any) -> Any:
         """Convenience method."""
-        return node.accept(self, *args, **kwargs)
+        return node.accept(self, **kwargs)
 
 
 OPTION = Option(id="uid")
@@ -40,8 +40,7 @@ OPTION = Option(id="uid")
 )
 def test_visit_default_is_invoked(node: AbstractSchemaNode) -> None:
     visitor = TestVisitor()
-    assert visitor.visit(node, 1, 2, a="a", b="b") == (
+    assert visitor.visit(node, a="a", b="b") == (
         "uid",
-        (1, 2),
         {"a": "a", "b": "b"},
     )


### PR DESCRIPTION
For simplicity, require visitors to pass named arguments only
