### PR TITLE
Apply input formatter to user text, not only examples

### DIFF
--- a/kor/encoders/encode.py
+++ b/kor/encoders/encode.py
@@ -19,7 +19,10 @@ InputFormatter = Union[
 ]
 
 
-def _format_text(text: str, input_formatter: InputFormatter = None) -> str:
+# PUBLIC API
+
+
+def format_text(text: str, input_formatter: InputFormatter = None) -> str:
     """An encoder for the input text.
 
     Args:
@@ -46,9 +49,6 @@ def _format_text(text: str, input_formatter: InputFormatter = None) -> str:
         )
 
 
-# PUBLIC API
-
-
 def encode_examples(
     examples: Sequence[Tuple[str, str]],
     encoder: Encoder,
@@ -58,7 +58,7 @@ def encode_examples(
 
     return [
         (
-            _format_text(input_example, input_formatter=input_formatter),
+            format_text(input_example, input_formatter=input_formatter),
             encoder.encode(output_example),
         )
         for input_example, output_example in examples

--- a/kor/prompts.py
+++ b/kor/prompts.py
@@ -14,7 +14,7 @@ from langchain.schema import (
 from pydantic import Extra
 
 from kor.encoders import Encoder
-from kor.encoders.encode import InputFormatter, encode_examples
+from kor.encoders.encode import InputFormatter, encode_examples, format_text
 from kor.encoders.parser import KorParser
 from kor.examples import generate_examples
 from kor.nodes import Object
@@ -44,6 +44,10 @@ class ExtractionPromptValue(PromptValue):
         extra = Extra.forbid
         arbitrary_types_allowed = True
 
+    def get_formatted_text(self) -> str:
+        """Get the text encoded if needed."""
+        return format_text(self.text, input_formatter=self.input_formatter)
+
     def to_string(self) -> str:
         """Format the template to a string."""
         instruction_segment = self.generate_instruction_segment(self.node)
@@ -58,7 +62,8 @@ class ExtractionPromptValue(PromptValue):
                 ]
             )
 
-        formatted_examples.append(f"Input: {self.text}\nOutput:")
+        text = self.get_formatted_text()
+        formatted_examples.append(f"Input: {text}\nOutput:")
         input_output_block = "\n".join(formatted_examples)
         return f"{instruction_segment}\n\n{input_output_block}"
 
@@ -77,7 +82,8 @@ class ExtractionPromptValue(PromptValue):
                 ]
             )
 
-        messages.append(HumanMessage(content=self.text))
+        content = self.get_formatted_text()
+        messages.append(HumanMessage(content=content))
         return messages
 
     def generate_encoded_examples(self, node: Object) -> List[Tuple[str, str]]:

--- a/tests/test_prompt_generation.py
+++ b/tests/test_prompt_generation.py
@@ -1,0 +1,35 @@
+import pytest
+
+from kor.prompts import create_langchain_prompt
+from kor import TypeScriptDescriptor, JSONEncoder
+from kor.encoders import InputFormatter
+from kor import Object
+
+
+@pytest.mark.parametrize(
+    "input_formatter, expected_string",
+    [
+        (None, 'user input'),
+        ("triple_quotes", '"""\nuser input\n"""'),
+        ("text_prefix", 'Text: """\nuser input\n"""'),
+    ],
+)
+def test_input_formatter_applied_correctly(
+    input_formatter: InputFormatter, expected_string: str
+) -> None:
+    untyped_object = Object(
+        id="obj",
+        examples=[("text", {"text": "text"})],
+        attributes=[],
+    )
+    prompt = create_langchain_prompt(
+        untyped_object,
+        JSONEncoder(),
+        TypeScriptDescriptor(),
+        input_formatter=input_formatter,
+    )
+
+    prompt_value = prompt.format_prompt(text="user input")
+
+    assert prompt_value.to_messages()[-1].content == expected_string
+    assert expected_string in prompt_value.to_string()

--- a/tests/test_prompt_generation.py
+++ b/tests/test_prompt_generation.py
@@ -1,15 +1,14 @@
 import pytest
 
-from kor.prompts import create_langchain_prompt
-from kor import TypeScriptDescriptor, JSONEncoder
+from kor import JSONEncoder, Object, TypeScriptDescriptor
 from kor.encoders import InputFormatter
-from kor import Object
+from kor.prompts import create_langchain_prompt
 
 
 @pytest.mark.parametrize(
     "input_formatter, expected_string",
     [
-        (None, 'user input'),
+        (None, "user input"),
         ("triple_quotes", '"""\nuser input\n"""'),
         ("text_prefix", 'Text: """\nuser input\n"""'),
     ],


### PR DESCRIPTION
After this PR, the input formatter, if provided, will be
applied to both the input part of the examples as well as to 
the actual user input.

Before this, it was not applied to user input.
