### PR TITLE
Fix examples bug for objects

### DIFF
--- a/kor/examples.py
+++ b/kor/examples.py
@@ -22,7 +22,7 @@ T = TypeVar("T")
 
 
 class SimpleExampleAggregator(AbstractVisitor[List[Tuple[str, str]]]):
-    """Use to visit node and all of its descendents and aggregates all examples."""
+    """Use to visit node and all of its descendants and aggregates all examples."""
 
     def visit_option(self, node: "Option", **kwargs: Any) -> List[Tuple[str, str]]:
         """Should not visit Options directly."""

--- a/kor/nodes.py
+++ b/kor/nodes.py
@@ -225,8 +225,8 @@ class Object(AbstractSchemaNode):
         Tuple[
             str,
             Union[
-                Mapping[str, Any],
                 Sequence[Mapping[str, Any]],
+                Mapping[str, Any],
             ],
         ]
     ] = tuple()


### PR DESCRIPTION
Pydantic auto coercision behaves incorrectly when using a list of dicts which
contain exactly 2 items. In this case, the list of dicts gets incorrectly
converted into a dictionary.

Fix for: https://github.com/eyurtsev/kor/issues/130
