### PR TITLE
Updating model kwargs usage in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,12 @@ from kor import create_extraction_chain, Object, Text
 llm = ChatOpenAI(
     model_name="gpt-3.5-turbo",
     temperature=0,
-    max_tokens=2000,
-    frequency_penalty=0,
-    presence_penalty=0,
-    top_p=1.0,
+    max_tokens=2000
+    model_kwargs = {
+        'frequency_penalty':0,
+        'presence_penalty':0,
+        'top_p':1.0
+    }
 )
 
 schema = Object(

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ from kor import create_extraction_chain, Object, Text
 llm = ChatOpenAI(
     model_name="gpt-3.5-turbo",
     temperature=0,
-    max_tokens=2000
+    max_tokens=2000,
     model_kwargs = {
         'frequency_penalty':0,
         'presence_penalty':0,

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -24,7 +24,7 @@ from kor import create_extraction_chain, Object, Text
 llm = ChatOpenAI(
     model_name="gpt-3.5-turbo",
     temperature=0,
-    max_tokens=2000
+    max_tokens=2000,
     model_kwargs = {
         'frequency_penalty':0,
         'presence_penalty':0,

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -24,10 +24,12 @@ from kor import create_extraction_chain, Object, Text
 llm = ChatOpenAI(
     model_name="gpt-3.5-turbo",
     temperature=0,
-    max_tokens=2000,
-    frequency_penalty=0,
-    presence_penalty=0,
-    top_p=1.0,
+    max_tokens=2000
+    model_kwargs = {
+        'frequency_penalty':0,
+        'presence_penalty':0,
+        'top_p':1.0
+    }
 )
 
 schema = Object(


### PR DESCRIPTION
The arguments `frequency_penalty`, `presence_penalty`, and `top_p` in ChatOpenAI have been moved from direct parameters to the `model_kwargs` parameter. In this PR, I'm updating `README.md` and `docs/source/index.md` to reflect that change.