### PR TITLE
Remove deprecated chain

### DIFF
--- a/kor/extraction/api.py
+++ b/kor/extraction/api.py
@@ -24,8 +24,10 @@ from kor.validators import Validator
 def set_verbose_context(verbose: bool):
     old_verbose = get_verbose()
     set_verbose(verbose)
-    yield
-    set_verbose(old_verbose)
+    try:
+        yield
+    finally:
+        set_verbose(old_verbose)
 
 
 async def _extract_from_document_with_semaphore(

--- a/kor/extraction/api.py
+++ b/kor/extraction/api.py
@@ -9,7 +9,7 @@ from langchain_core.documents import Document
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import PromptTemplate
-from langchain_core.runnables import RunnableSequence
+from langchain_core.runnables import Runnable
 
 from kor.encoders import Encoder, InputFormatter, initialize_encoder
 from kor.extraction.parser import KorParser
@@ -32,7 +32,7 @@ def set_verbose_context(verbose: bool):
 
 async def _extract_from_document_with_semaphore(
     semaphore: asyncio.Semaphore,
-    chain: RunnableSequence,
+    chain: Runnable,
     document: Document,
     uid: str,
     source_uid: str,
@@ -66,7 +66,7 @@ def create_extraction_chain(
     instruction_template: Optional[PromptTemplate] = None,
     verbose: Optional[bool] = None,
     **encoder_kwargs: Any,
-) -> RunnableSequence:
+) -> Runnable:
     """Create an extraction chain.
     
     Args:
@@ -132,7 +132,7 @@ def create_extraction_chain(
 
 
 async def extract_from_documents(
-    chain: RunnableSequence,
+    chain: Runnable,
     documents: Sequence[Document],
     *,
     max_concurrency: int = 1,

--- a/tests/extraction/test_extraction_with_chain.py
+++ b/tests/extraction/test_extraction_with_chain.py
@@ -2,8 +2,6 @@
 from typing import Any, Mapping, Optional
 
 import pytest
-from langchain.globals import get_verbose
-from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import Runnable
 
 from kor.encoders import CSVEncoder, JSONEncoder
@@ -105,43 +103,14 @@ def test_not_implemented_assertion_raised_for_csv(options: Mapping[str, Any]) ->
         create_extraction_chain(chat_model, **options)
 
 
-@pytest.mark.parametrize("verbose", [True, False, None])
+@pytest.mark.parametrize("verbose", [True, False])
 def test_instantiation_with_verbose_flag(verbose: Optional[bool]) -> None:
     """Create an extraction chain."""
     chat_model = ToyChatModel(response="hello")
-    chain = create_extraction_chain(
-        chat_model,
-        SIMPLE_OBJECT_SCHEMA,
-        encoder_or_encoder_class="json",
-        verbose=verbose,
-    )
-    assert isinstance(chain, Runnable)
-    expected_verbose = verbose if verbose is not None else get_verbose()
-    assert chain.verbose == expected_verbose
-
-
-def test_using_custom_template() -> None:
-    """Create an extraction chain with a custom template."""
-    template = PromptTemplate(
-        input_variables=["format_instructions", "type_description"],
-        template=(
-            "custom_prefix\n"
-            "{type_description}\n\n"
-            "{format_instructions}\n"
-            "custom_suffix"
-        ),
-    )
-    chain = create_extraction_chain(
-        ToyChatModel(response="hello"),
-        OBJECT_SCHEMA_WITH_MANY,
-        instruction_template=template,
-        encoder_or_encoder_class="json",
-    )
-    prompt_value = chain.prompt.format_prompt(text="hello")
-    system_message = prompt_value.to_messages()[0]
-    string_value = prompt_value.to_string()
-
-    assert "custom_prefix" in string_value
-    assert "custom_suffix" in string_value
-    assert "custom_prefix" in system_message.content
-    assert "custom_suffix" in system_message.content
+    with pytest.raises(NotImplementedError):
+        create_extraction_chain(
+            chat_model,
+            SIMPLE_OBJECT_SCHEMA,
+            encoder_or_encoder_class="json",
+            verbose=verbose,
+        )

--- a/tests/extraction/test_extraction_with_chain.py
+++ b/tests/extraction/test_extraction_with_chain.py
@@ -1,10 +1,10 @@
 """Test that the extraction chain works as expected."""
 from typing import Any, Mapping, Optional
 
-import langchain
 import pytest
-from langchain.chains import LLMChain
+from langchain.globals import get_verbose
 from langchain_core.prompts import PromptTemplate
+from langchain_core.runnables import RunnableSequence
 
 from kor.encoders import CSVEncoder, JSONEncoder
 from kor.extraction import create_extraction_chain
@@ -40,7 +40,7 @@ def test_create_extraction_chain(options: Mapping[str, Any]) -> None:
 
     for schema in [SIMPLE_OBJECT_SCHEMA]:
         chain = create_extraction_chain(chat_model, schema, **options)
-        assert isinstance(chain, LLMChain)
+        assert isinstance(chain, RunnableSequence)
         # Try to run through predict and parse
         chain.invoke("some string")  # type: ignore
 
@@ -60,7 +60,7 @@ def test_create_extraction_chain_with_csv_encoder(options: Mapping[str, Any]) ->
     chat_model = ToyChatModel(response="hello")
 
     chain = create_extraction_chain(chat_model, **options)
-    assert isinstance(chain, LLMChain)
+    assert isinstance(chain, RunnableSequence)
     # Try to run through predict and parse
     chain.invoke("some string")  # type: ignore
 
@@ -115,11 +115,8 @@ def test_instantiation_with_verbose_flag(verbose: Optional[bool]) -> None:
         encoder_or_encoder_class="json",
         verbose=verbose,
     )
-    assert isinstance(chain, LLMChain)
-    if verbose is None:
-        expected_verbose = langchain.verbose
-    else:
-        expected_verbose = verbose
+    assert isinstance(chain, RunnableSequence)
+    expected_verbose = verbose if verbose is not None else get_verbose()
     assert chain.verbose == expected_verbose
 
 

--- a/tests/extraction/test_extraction_with_chain.py
+++ b/tests/extraction/test_extraction_with_chain.py
@@ -4,7 +4,7 @@ from typing import Any, Mapping, Optional
 import pytest
 from langchain.globals import get_verbose
 from langchain_core.prompts import PromptTemplate
-from langchain_core.runnables import RunnableSequence
+from langchain_core.runnables import Runnable
 
 from kor.encoders import CSVEncoder, JSONEncoder
 from kor.extraction import create_extraction_chain
@@ -40,7 +40,7 @@ def test_create_extraction_chain(options: Mapping[str, Any]) -> None:
 
     for schema in [SIMPLE_OBJECT_SCHEMA]:
         chain = create_extraction_chain(chat_model, schema, **options)
-        assert isinstance(chain, RunnableSequence)
+        assert isinstance(chain, Runnable)
         # Try to run through predict and parse
         chain.invoke("some string")  # type: ignore
 
@@ -60,7 +60,7 @@ def test_create_extraction_chain_with_csv_encoder(options: Mapping[str, Any]) ->
     chat_model = ToyChatModel(response="hello")
 
     chain = create_extraction_chain(chat_model, **options)
-    assert isinstance(chain, RunnableSequence)
+    assert isinstance(chain, Runnable)
     # Try to run through predict and parse
     chain.invoke("some string")  # type: ignore
 
@@ -115,7 +115,7 @@ def test_instantiation_with_verbose_flag(verbose: Optional[bool]) -> None:
         encoder_or_encoder_class="json",
         verbose=verbose,
     )
-    assert isinstance(chain, RunnableSequence)
+    assert isinstance(chain, Runnable)
     expected_verbose = verbose if verbose is not None else get_verbose()
     assert chain.verbose == expected_verbose
 


### PR DESCRIPTION
Hey @eyurtsev 

Here are the listed changes:

- kor/extraction/api.py: Removed deprecated `LLMChain` and `arun` and instead replaced them with `RunnableSequence` and `ainvoke` respectively, Added set_verbose context to set the verbosity within the context of a function to mimic the old `chain_kwargs` verbose functionality.
- tests/extraction/test_extraction_with_chain.py: Removed deprecated `LLMChain`, mimic `langchain.verbose` with `get_verbose()`


Please let me know if any changes need to be made. Merging this fixes #305.

Cheers,
Sachin