### PR TITLE
Release 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kor"
-version = "1.0.2"
+version = "2.0.0"
 description = "Extract information with LLMs from text"
 authors = ["Eugene Yurtsev <eyurtsev@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- Replace LLMChain with Runnable
- To get the prompt use chain.get_prompts()
- verbose has been deprecated and users should use langchain.globals set_verbose and set_debug